### PR TITLE
Add repository field and some dev-dependancies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,21 @@
   "id": "fxdevtools-adapters@mozilla.org",
   "description": "Protocl Adapters for Firefox Developer Tools",
   "author": "Dave Camp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/campd/fxdt-adapters"
+  },
   "license": "MPL 2.0",
   "version": "0.0.1",
-  "main": "lib/main.js"
+  "main": "lib/main.js",
+  "devDependencies": {
+    "deepmerge": "^0.2.7",
+    "firefox-profile": "^0.3.3",
+    "grunt": "~0.4.5",
+    "grunt-shell": "^0.7.0",
+    "grunt-webdriver": "^0.4.1",
+    "prompt": "^0.2.13",
+    "request": "^2.40.0",
+    "ws": "^0.4.32"
+  }
 }


### PR DESCRIPTION
These are a couple of things I noticed when pulling down the project and trying to run it locally.  It makes it possible to run `npm install`, `node proxy.js`, and `grunt`.
