### PR TITLE
Issue #13 - Inspector breaks after page navigation

### DIFF
--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -323,6 +323,7 @@ var ChromiumWalkerActor = protocol.ActorClass({
     this.rpc.on("DOM.childNodeCountUpdated", this.onChildNodeCountUpdated.bind(this));
 
     this.rpc.on("Page.frameNavigated", this.onFrameNavigated.bind(this));
+    this.rpc.on("Page.loadEventFired", this.onPageLoad.bind(this));
   },
 
   init: task.async(function*() {
@@ -545,7 +546,7 @@ var ChromiumWalkerActor = protocol.ActorClass({
     });
   },
 
-  onFrameNavigated: task.async(function(params) {
+  onFrameNavigated: function(params) {
     if (!params.frame.parentId) {
       // Urgh, should probably block further communication during this
       // XXX
@@ -555,10 +556,18 @@ var ChromiumWalkerActor = protocol.ActorClass({
       });
 
       this.releaseNode(this.root);
+      this.hasNavigated = true;
+    }
+  },
+
+  onPageLoad: task.async(function(params) {
+    if (this.hasNavigated) {
+      this.hasNavigated = false;
+
       this.generation++;
+
       let result = yield this.rpc.request("DOM.getDocument");
       this.root = this.ref(result.root);
-
 
       this.queueMutation({
         type: "newRoot",


### PR DESCRIPTION
This sort of helps a little bit.
The downside is that as long as the new frame isn't totally loaded, the markup-view doesn't appear (which btw is the same on FirefoxDevTools with Firefox).
The upside is that it kind of fixes the problem by stopping what I think is a race condition from happening.
