### PR TITLE
Fix #17 - Update box-model panel on reflow

### DIFF
--- a/lib/chromium/reflow.js
+++ b/lib/chromium/reflow.js
@@ -1,0 +1,106 @@
+const {emit} = require("../devtools/event"); // Needs to share a loader with protocol.js, boo.
+const task = require("../util/task");
+
+const protocol = require("../devtools/server/protocol");
+const {asyncMethod} = require("../util/protocol-extra");
+const {Actor, ActorClass, Pool, method, Arg, Option, RetVal, types} = protocol;
+const {setTimeout, clearTimeout} = require("sdk/timers");
+
+/**
+ * The reflow actor groups a few of the CSS and Page domain events from the
+ * chrome remote debugging protocol into a "reflows" event that is sent to the
+ * front-end so that consumers can refresh.
+ * One such consumer is the layout-view sidebar panel in the inspector.
+ */
+
+const EVENT_BATCHING_DELAY = 300; // ms
+const LAYOUT_INVALIDATION_EVENTS = [
+  // XXX: some of these events aren't available on IOS, but since DOM.getBoxModel
+  // isn't available either (see styles.js) the layout-view panel won't work
+  // anyway.
+  "CSS.mediaQueryResultChanged",
+  "CSS.styleSheetAdded",
+  "CSS.styleSheetChanged",
+  "CSS.styleSheetRemoved",
+  "DOM.inlineStyleInvalidated",
+  "Page.frameResized"
+];
+
+var ChromiumReflowActor = ActorClass({
+  typeName: "chromium_reflow",
+
+  events: {
+    /**
+     * The reflows event is emitted when reflows have been detected. The event
+     * is sent with an array of reflows that occured since the last event, as
+     * events are sent at most every EVENT_BATCHING_DELAY ms.
+     */
+    "reflows" : {
+      type: "reflows",
+      reflows: Arg(0, "array:json")
+    }
+  },
+
+  initialize(tab) {
+    Actor.prototype.initialize.call(this, tab.conn);
+    this.tab = tab;
+    this.rpc = tab.rpc;
+
+    this.onReflow = this.onReflow.bind(this);
+
+    this._isStarted = false;
+  },
+
+  start: method(function() {
+    if (!this._isStarted) {
+      this._isStarted = true;
+      this._reflows = [];
+
+      for (let event of LAYOUT_INVALIDATION_EVENTS) {
+        this.rpc.on(event, this.onReflow);
+      }
+    }
+  }, {oneway: true}),
+
+  stop: method(function() {
+    if (this._isStarted) {
+      clearTimeout(this.eventBatchingTimeout);
+      this.eventBatchingTimeout = null;
+
+      for (let event of LAYOUT_INVALIDATION_EVENTS) {
+        this.rpc.off(event, this.onReflow);
+      }
+
+      this._reflows = [];
+      this._isStarted = false;
+    }
+  }, {oneway: true}),
+
+  onReflow(event) {
+    // Note that for now, we just consider any of the observed event to cause a
+    // reflow.
+
+    // XXX On Firefox, we actually can listen to reflows and get a start/end
+    // time and know if it was interruptible or not. On Chrome, we can't do that
+    // and instead we listen to a few different events, so the reflow objects
+    // sent are empty, but since only the layout-view uses the events and
+    // doesn't require start/end/isInterruptible, this isn't going to be an
+    // issue.
+    this._reflows.push({});
+
+    if (!this.eventBatchingTimeout) {
+      this.eventBatchingTimeout = setTimeout(this._sendBatchedEvents.bind(this),
+                                             EVENT_BATCHING_DELAY);
+    }
+  },
+
+  _sendBatchedEvents() {
+    if (this._reflows.length) {
+      emit(this, "reflows", this._reflows);
+      this._reflows = [];
+      this.eventBatchingTimeout = null;
+    }
+  }
+});
+
+exports.ChromiumReflowActor = ChromiumReflowActor;

--- a/lib/chromium/root.js
+++ b/lib/chromium/root.js
@@ -14,6 +14,7 @@ const {asyncMethod} = require("../util/protocol-extra");
 
 const {ChromiumConsoleActor} = require("./webconsole");
 const {ChromiumInspectorActor} = require("./inspector");
+const {ChromiumReflowActor} = require("./reflow");
 const {ChromiumStyleSheetsActor} = require("./styles");
 const {ChromiumThreadActor} = require("./thread")
 
@@ -172,6 +173,9 @@ var ChromiumTabActor = ActorClass({
     this.inspectorActorID = conn.manageLazy(this, conn.allocID(), () => {
       return ChromiumInspectorActor(this);
     });
+    this.reflowActorID = conn.manageLazy(this, conn.allocID(), () => {
+      return ChromiumReflowActor(this);
+    });
     this.styleSheetsActorID = conn.manageLazy(this, conn.allocID(), () => {
       return ChromiumStyleSheetsActor(this);
     });
@@ -184,6 +188,7 @@ var ChromiumTabActor = ActorClass({
       url: this.json.url,
       consoleActor: this.consoleActorID,
       inspectorActor: this.inspectorActorID,
+      reflowActor: this.reflowActorID,
       styleSheetsActor: this.styleSheetsActorID
     }
   },

--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -335,6 +335,7 @@ var ChromiumPageStyleActor = protocol.ActorClass({
   }),
 
   getLayout: asyncMethod(function*(node) {
+    // XXX: This request isn't compatible with the IOS protocol
     response = yield this.rpc.request("DOM.getBoxModel", {
       nodeId: node.handle.nodeId,
     });


### PR DESCRIPTION
Introduces a new Reflow actor that listens to a few remote protocol CSS/Page/DOM change events to then fire a reflow event to the front-end.
