### PR TITLE
Display image preview tooltips for all kinds of image URLs

### DIFF
--- a/lib/chromium/resource-store.js
+++ b/lib/chromium/resource-store.js
@@ -74,10 +74,6 @@ var ResourceStore = Class({
     url = normalize(url);
 
     for (let frame of this.frames) {
-      // XXX Yeucch also, for cases where the url doesn't have a protocol prefix
-      if (url.startsWith("//")) {
-        url = frame.frame.url.substring(0, frame.frame.url.indexOf("//")) + url;
-      }
       if (frame.frame.url === url) {
         return yield this.frameContent(frame.frame);
       }

--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -1,4 +1,4 @@
-const { Ci, Cc } = require("chrome");
+const { Ci, Cu, Cc } = require("chrome");
 
 const {emit} = require("../devtools/event"); // Needs to share a loader with protocol.js, boo.
 const task = require("../util/task");
@@ -10,6 +10,7 @@ const {ChromiumPageStyleActor} = require("./styles");
 const {ChromiumHighlighterActor} = require("./highlighter");
 const {LongStringActor} = require("../devtools/server/actors/string");
 const {getResourceStore} = require("./resource-store");
+Cu.importGlobalProperties(["URL"]);
 
 const SUMMARY_VALUE_LENGTH = 50;
 
@@ -164,19 +165,66 @@ var NodeActor = protocol.ActorClass({
     response: {}
   }),
 
+  /**
+   * Get the base URL of this node's parent document.
+   * @return {URL}
+   */
+  _getBaseURL() {
+    let node = this;
+    while (node.parent) {
+      node = node.parent;
+    }
+    return new URL(node.handle.baseURL);
+  },
+
+  /**
+   * Given a URL, return its absolute version, based on this node's document
+   * base URL.
+   * @param {String} url
+   * @return {String}
+   */
+  _getAbsoluteURL(url) {
+    let baseURL = this._getBaseURL();
+
+    if (url.startsWith("//")) {
+      // Missing protocol
+      url = baseURL.protocol + url;
+    } else if (url.startsWith("/")) {
+      // Absolute url
+      url = baseURL.origin + url;
+    } else if (!url.startsWith(baseURL.protocol)) {
+      // Relative path
+      let path = baseURL.pathname.substring(0, baseURL.pathname.lastIndexOf("/") + 1);
+      url = baseURL.origin + path + url;
+    }
+
+    return url;
+  },
+
   getImageData: asyncMethod(function*() {
     let url = this.getAttr("src");
     if (!url) {
       return;
     }
 
-    let resourceStore = getResourceStore(this.rpc);
-    let {content, base64Encoded} = yield resourceStore.urlContent(url);
+    url = this._getAbsoluteURL(url);
+    if (!url) {
+      return;
+    }
 
+    let resourceStore = getResourceStore(this.rpc);
+    let urlContent = yield resourceStore.urlContent(url);
+    if (!urlContent) {
+      return;
+    }
+
+    let {content, base64Encoded} = urlContent;
     if (base64Encoded) {
       return {
         data: LongStringActor(this.conn, "data:image/png;base64," + content),
-        size: {} // XXX
+        // Sending empty size information will cause the front-end to load the
+        // image to retrieve the dimension.
+        size: {}
       };
     }
   }, {


### PR DESCRIPTION
Image preview tooltips kind of worked since last week, but not for relative image sources. This should fix it.
