### PR TITLE
Enable copy innerHTML by parsing outerHTML

### DIFF
--- a/lib/chromium/highlighter.js
+++ b/lib/chromium/highlighter.js
@@ -55,14 +55,16 @@ var ChromiumHighlighterActor = protocol.ActorClass({
       highlightConfig: this.highlightConfig
     });
 
+    // XXX: the protocol doesn't send notifications when nodes are being hovered
+    // when the inspect mode is enabled, so "picker-node-hovered" cannot be sent
+    // which means the markup-view won't live-update as the mouse moves.
+
     this.inspector.walker.on("picker-node-picked", task.async(function*(args) {
       yield this.rpc.request("DOM.setInspectModeEnabled", {
         enabled: false
       });
       timers.setTimeout(function() {}, HIGHLIGHTER_PICKED_TIMER);
     }));
-//    events.emit(this._walker, "picker-node-picked", this._findAndAttachElement(event));
-//    events.emit(this._walker, "picker-node-hovered", res);
   }),
 
   cancelPick: method(function() {

--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -1,4 +1,4 @@
-const { Ci } = require("chrome");
+const { Ci, Cc } = require("chrome");
 
 const {emit} = require("../devtools/event"); // Needs to share a loader with protocol.js, boo.
 const task = require("../util/task");
@@ -887,7 +887,34 @@ var ChromiumWalkerActor = protocol.ActorClass({
     request: { node: Arg(0, "chromium_domnode") }
   }),
 
-  innerHTML: todoMethod({
+  innerHTML: asyncMethod(function*(node) {
+    // XXX: The protocol doesn't support getInnerHTML, so use the outerHTML,
+    // parse it, and get the innerHTML from that.
+    let {outerHTML} = yield this.rpc.request("DOM.getOuterHTML", {
+      nodeId: node.handle.nodeId
+    });
+
+    let DOMParser = Cc["@mozilla.org/xmlextras/domparser;1"].createInstance(
+      Ci.nsIDOMParser);
+
+    let el = DOMParser.parseFromString(outerHTML, "text/html");
+
+    // The HTML parser wraps the node in <html><body> except if the node is
+    // <html>, <body, <head>, <title>, ...
+    let htmlGetters = {
+      "html": el => el.head.outerHTML + el.body.outerHTML,
+      "body": el => el.body.innerHTML,
+      "head": el => el.head.innerHTML,
+      "title": el => el.head.children[0].innerHTML,
+      "meta": el => el.head.children[0].innerHTML,
+      "default": el => el.body.children[0].innerHTML
+    };
+
+    let tagName = node.handle.nodeName.toLowerCase();
+    let htmlGetter = htmlGetters[tagName] || htmlGetters.default;
+
+    return new LongStringActor(this.conn, htmlGetter(el));
+  }, {
     request: { node: Arg(0, "chromium_domnode") },
     response: { value: RetVal("longstring") }
   }),


### PR DESCRIPTION
The markup-view "Copy inner HTML" context menu doesn't work right now as the `innerHTML` walker method is marked as TODO.
The downstream protocol doesn't support `getInnerHTML` unfortunately, but I reckon we can use `getOuterHTML`, parse the result and get the inner HTML from that.
The attached code should work in most cases.
