### PR TITLE
Fix a number of errors that prevented the initialization of the add-on.

### DIFF
--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -634,9 +634,9 @@ var ChromiumStyleRuleActor = protocol.ActorClass({
     range.startLine = point.line;
     range.startColumn = point.column;
 
-    let point = this.adjustPoint(oldRange, newRange, range.endLine, range.endColumn);
-    range.startLine = point.line;
-    range.startColumn = point.column;
+    let point2 = this.adjustPoint(oldRange, newRange, range.endLine, range.endColumn);
+    range.endLine = point2.line;
+    range.endColumn = point2.column;
 
     return true;
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -147,9 +147,9 @@ let action_button = ui.ActionButton({
     }
 
     let client = response.client;
-    let response = response.response;
+    let resp = response.response;
 
-    let tab = response.tabs[response.selected];
+    let tab = resp.tabs[resp.selected];
     try {
       yield openToolbox(client, tab, {}, {
         tool: "inspector",


### PR DESCRIPTION
Shu's recent changes to the behavior of 'let' broke the add-on. This fixes it, but it would be best if @captainbrosset made sure I didn't mess the inspector code up.
