### PR TITLE
Display image tooltips in the rule-view for background urls

### DIFF
--- a/lib/chromium/inspector.js
+++ b/lib/chromium/inspector.js
@@ -7,6 +7,8 @@ const {Actor, ActorClass, Pool, method, Arg, Option, RetVal, types} = protocol;
 const {ChromiumWalkerActor} = require("./walker");
 const {ChromiumPageStyleActor} = require("./styles");
 const {ChromiumHighlighterActor} = require("./highlighter");
+const {LongStringActor} = require("../devtools/server/actors/string");
+const {getResourceStore} = require("./resource-store");
 
 var ChromiumInspectorActor = ActorClass({
   typeName: "chromium_inspector",
@@ -52,6 +54,27 @@ var ChromiumInspectorActor = ActorClass({
   }, {
     request: { autohide: Arg(0, "boolean") },
     response: { highligter: RetVal("chromium_highlighter") }
+  }),
+
+  getImageDataFromURL: asyncMethod(function*(url, maxDim) {
+    let resourceStore = getResourceStore(this.rpc);
+    let urlContent = yield resourceStore.urlContent(url);
+    if (!urlContent) {
+      return;
+    }
+
+    let {content, base64Encoded} = urlContent;
+    if (base64Encoded) {
+      return {
+        data: LongStringActor(this.conn, "data:image/png;base64," + content),
+        // Sending empty size information will cause the front-end to load the
+        // image to retrieve the dimension.
+        size: {}
+      }
+    }
+  }, {
+    request: {url: Arg(0), maxDim: Arg(1, "nullable:number")},
+    response: RetVal("chromium_imageData")
   })
 });
 exports.ChromiumInspectorActor = ChromiumInspectorActor;

--- a/lib/chromium/root.js
+++ b/lib/chromium/root.js
@@ -62,7 +62,7 @@ var ChromiumRootActor = ActorClass({
         sources: false,
         editOuterHTML: true,
         highlightable: true,
-        urlToImageDataResolver: false,
+        urlToImageDataResolver: true,
         networkMonitor: false,
         storageInspector: false,
         storageInspectorReadOnly: false,

--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -570,6 +570,8 @@ var ChromiumStyleRuleActor = protocol.ActorClass({
 
     if (this.handle.styleSheetId) {
       form.parentStyleSheet = this.pageStyle.sheetRef(this.handle.styleSheetId).actorID;
+    } else if (this.handle.sourceURL) {
+      form.href = this.handle.sourceURL;
     } else {
       form.href = "http://idontknowwhatimdoing/"
     }


### PR DESCRIPTION
This is a start, there might be problems with it still, but we do get, at least some, tooltips in the rule-view.
