### PR TITLE
Store the new nodeValue when it is changed via the markup-view

### DIFF
--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -535,6 +535,8 @@ var ChromiumWalkerActor = protocol.ActorClass({
       return;
     }
 
+    node.handle.nodeValue = params.characterData;
+
     let mutation = {
       type: "characterData",
       target: node.actorID,


### PR DESCRIPTION
Not sure that's the right approach, but it does fix the problem whereby changing textcontent in the markup-view does change it on the device but reverts it in the markup-view.
Should RPC requests respond with a new handle to replace instead?
