### PR TITLE
Fix #25 - React to Inspector.inspect events to enable the picker on iOS

### DIFF
--- a/lib/chromium/root.js
+++ b/lib/chromium/root.js
@@ -218,6 +218,8 @@ var ChromiumTabActor = ActorClass({
    * Subscribe to tab navigation events and enable inspection.
    */
   attach: asyncMethod(function*() {
+    yield this.rpc.request("Inspector.enable");
+
     this.resources = resources.getResourceStore(this.rpc);
     this.sheets = sheets.getCSSStore(this.rpc);
 
@@ -292,6 +294,7 @@ var ChromiumTabActor = ActorClass({
    */
   detach: asyncMethod(function*() {
     yield this.rpc.request("Page.disable");
+    yield this.rpc.request("Inspector.disable");
   }, {
     request: {},
     response: {}

--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -376,8 +376,13 @@ var ChromiumWalkerActor = protocol.ActorClass({
 
     this.pseudoLockedNodes = new Set();
 
-    this.rpc.on("DOM.setChildNodes", this.onSetChildNodes.bind(this));
+    // Element picked event, for Chrome
     this.rpc.on("DOM.inspectNodeRequested", this.onInspectNodeRequested.bind(this));
+    // And iOS
+    this.rpc.on("Inspector.inspect", this.onInspectorInspect.bind(this));
+
+    // Markup mutation events
+    this.rpc.on("DOM.setChildNodes", this.onSetChildNodes.bind(this));
     this.rpc.on("DOM.attributeRemoved", this.onAttributeRemoved.bind(this));
     this.rpc.on("DOM.attributeModified", this.onAttributeModified.bind(this));
     this.rpc.on("DOM.characterDataModified", this.onCharacterDataModified.bind(this));
@@ -385,6 +390,7 @@ var ChromiumWalkerActor = protocol.ActorClass({
     this.rpc.on("DOM.childNodeInserted", this.onChildNodeInserted.bind(this));
     this.rpc.on("DOM.childNodeCountUpdated", this.onChildNodeCountUpdated.bind(this));
 
+    // Frame navigation events
     this.rpc.on("Page.frameNavigated", this.onFrameNavigated.bind(this));
     this.rpc.on("Page.loadEventFired", this.onPageLoad.bind(this));
   },
@@ -440,6 +446,10 @@ var ChromiumWalkerActor = protocol.ActorClass({
     this.updateChildren(parent, params.nodes);
   },
 
+  /**
+   * The chromium's version of "a node was selected" event where |params|
+   * has the nodeId directly.
+   */
   onInspectNodeRequested: function(params) {
     let node = this.refMap.get(params.nodeId);
     emit(this, "picker-node-picked", {
@@ -447,6 +457,18 @@ var ChromiumWalkerActor = protocol.ActorClass({
       newParents: [...this.ensurePathToRoot(node)]
     });
   },
+
+  /**
+   * The iOS's version of "a node was selected" event where |params| gives us a
+   * runtime objectId from which the nodeId can be retrieved.
+   */
+  onInspectorInspect: task.async(function*(params) {
+    let result = yield this.rpc.request("DOM.requestNode", {
+      objectId: params.object.objectId
+    });
+
+    this.onInspectNodeRequested(result);
+  }),
 
   queueMutation: function(mutation) {
     if (!this.actorID) {


### PR DESCRIPTION
It turns out we indeed need to enable/disable the Inspector domain before being able to listen to its events.
But on top of this, the response we get when the `inspect` event fires only contains a runtime object ID, which we need to translate into a node ID thanks to `DOM.requestNode`.
So it's going to be a little slower on iOS than on Chromium, but it should work.
