### PR TITLE
Fixes #32, Fixes #34, and fixes the stylesheet href on chrome

### DIFF
--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -254,6 +254,8 @@ var ChromiumPageStyleActor = protocol.ActorClass({
 
     yield this.addElementRules(node, undefined, options, result);
 
+    // XXX: Shouldn't we just use CSS.getMatchedStylesForNode's inherited flag
+    // and avoid calling the request for every parent?
     if (options.inherited) {
       let parent = node.parent;
       while (parent && parent.handle.nodeType === Ci.nsIDOMNode.ELEMENT_NODE) {
@@ -293,8 +295,11 @@ var ChromiumPageStyleActor = protocol.ActorClass({
       }
 
       let matchedSelectors = [];
-      if (matchingSelectors && style.selectorList) {
-        matchedSelectors = [for (i of matchingSelectors) style.selectorList.selectors[i].value ];
+      if (matchingSelectors && style.handle.selectorList) {
+        for (let i of matchingSelectors) {
+          let selector = style.handle.selectorList.selectors[i];
+          matchedSelectors.push(selector.value || selector);
+        }
       }
 
       result.entries.push({
@@ -325,7 +330,7 @@ var ChromiumPageStyleActor = protocol.ActorClass({
       inherited: false
     });
 
-    for (let match of response.matchedCSSRules || []) {
+    for (let match of response.matchedCSSRules.reverse() || []) {
       let ruleHandle = match.rule;
       let style = this.styleRef(ruleHandle);
       addStyle(style, match.matchingSelectors);
@@ -558,7 +563,8 @@ var ChromiumStyleRuleActor = protocol.ActorClass({
       type: this.type || STYLE_RULE
     }
 
-    if (this.handle.styleSheetId && this.handle.selectorList) {
+    let styleSheetId = this.handle.style.styleSheetId;
+    if (styleSheetId && this.handle.selectorList) {
       let start = this.handle.selectorList.selectors[0];
       form.line = start.startLine;
       form.column = start.startColumn;
@@ -568,8 +574,8 @@ var ChromiumStyleRuleActor = protocol.ActorClass({
       form.parentRule = undefined;
     }
 
-    if (this.handle.styleSheetId) {
-      form.parentStyleSheet = this.pageStyle.sheetRef(this.handle.styleSheetId).actorID;
+    if (styleSheetId) {
+      form.parentStyleSheet = this.pageStyle.sheetRef(styleSheetId).actorID;
     } else if (this.handle.sourceURL) {
       form.href = this.handle.sourceURL;
     } else {


### PR DESCRIPTION
Matched selectors are now properly highlighted in the rule-view.
Applied rules are now also in the right order.
Finally, parent stylesheet href is now correct, at least on Chrome (still says 'inline' on ios).
