### PR TITLE
Introduces a couple of prefs to control what gets logged, and removes some debug logs

### DIFF
--- a/lib/chromium/resource-store.js
+++ b/lib/chromium/resource-store.js
@@ -103,15 +103,11 @@ var ResourceStore = Class({
 
   frameForUrl: function(url) {
     for (let frame of this.frames) {
-      console.log(" checking for: " + frame.frame.url);
       if (frame.frame.url === url) {
-        console.log("returning frame");
         return frame.frame;
       }
       for (let resource of frame.resources || []) {
-        console.log("checking: " + resource.url);
         if (resource.url === url) {
-          console.log("returning frame");
           return frame.frame;
         }
       }

--- a/lib/chromium/root.js
+++ b/lib/chromium/root.js
@@ -27,13 +27,11 @@ protocol.types.addDictType("chromium_tablist", {
 });
 
 function requestTabs(url) {
-  console.log("Requesting tabs from: " + url);
   return new Promise((resolve, reject) => {
     let tabsRequest = request.Request({
       url: url,
       onComplete: function(response) {
         if (response.status === 200 && response.json.length > 0) {
-          console.log("response: " + JSON.stringify(response.json));
           resolve(response.json);
         } else {
           reject(response.statusText);
@@ -74,8 +72,6 @@ var ChromiumRootActor = ActorClass({
 
   listTabs: asyncMethod(function*() {
     let jsonTabs = yield requestTabs(this.conn.url + "/json");
-
-    console.log("tabs: " + JSON.stringify(jsonTabs));
 
     let response = {
       tabs: []
@@ -260,9 +256,7 @@ var ChromiumTabActor = ActorClass({
   }),
 
   reconfigure: method(function(options) {
-    console.log(1);
     if (typeof options.cacheDisabled !== "undefined") {
-      console.log(2);
       yield this.rpc.request("Network.setCacheDisabled", {
         cacheDisabled: options.cacheDisabled
       });

--- a/lib/chromium/rpc.js
+++ b/lib/chromium/rpc.js
@@ -2,16 +2,14 @@ const { Class } = require("sdk/core/heritage");
 const task = require("../util/task");
 const {EventTarget} = require("sdk/event/target");
 const {emit} = require("sdk/event/core");
+const {prefs} = require("sdk/simple-prefs");
 
 const win = require("sdk/addon/window");
 const WebSocket = win.window.WebSocket;
 
-const debugTruncate = 320;
-
 var TabConnection = Class({
   extends: EventTarget,
   initialize: function(tabJSON) {
-    console.log("Tab created: " + tabJSON.url);
     this.json = tabJSON;
     this.requestID = 1;
     this.outstandingRequests = new Map();
@@ -20,29 +18,37 @@ var TabConnection = Class({
   connect: function() {
     if (!this.connecting) {
       this.connecting = new Promise((resolve, reject) => {
-        console.log("Connecting to " + this.json.webSocketDebuggerUrl + "...");
+        if (prefs["logDeviceProtocolTraffic"]) {
+          console.log("<<<<<< Connecting to " + this.json.webSocketDebuggerUrl + "...");
+        }
         let socket = new WebSocket(this.json.webSocketDebuggerUrl, []);
         this.socket = socket;
         socket.onopen = () => {
-          console.log("Connection established.");
+          if (prefs["logDeviceProtocolTraffic"]) {
+            console.log(">>>>>> Connection established");
+          }
           resolve();
         }
         socket.onmessage = this.onMessage.bind(this);
-        socket.onclose = e => console.log("Web socket closed: " + e.code + "/" + e.reason);
+        socket.onclose = e => {
+          if (prefs["logDeviceProtocolTraffic"]) {
+            console.log(">>>>>> Web socket closed: " + e.code + "/" + e.reason);
+          }
+        }
         socket.oncerror = e => console.error("Error occurred in web socket: " + e);
-        console.log("Created web socket connection: " + socket.readyState);
       });
     }
     return this.connecting;
   },
 
   close: function() {
-    console.log("Closing web socket connection.");
     this.socket.close();
   },
 
   onMessage: function(evt) {
-    console.log("GOT A PACKET: " + evt.data.substring(0, debugTruncate));
+    if (prefs["logDeviceProtocolTraffic"]) {
+      console.log(">>>>>> Received from device\n" + evt.data);
+    }
     let packet = JSON.parse(evt.data);
     if ("id" in packet && this.outstandingRequests.has(packet.id)) {
       let p = this.outstandingRequests.get(packet.id);
@@ -65,7 +71,9 @@ var TabConnection = Class({
         method: method,
         params: params
       };
-      console.log("SENDING: " + JSON.stringify(request).substring(0, debugTruncate));
+      if (prefs["logDeviceProtocolTraffic"]) {
+        console.log("<<<<<< Sent to device\n" + JSON.stringify(request));
+      }
       this.outstandingRequests.set(request.id, { resolve: resolve, reject: reject });
       this.socket.send(JSON.stringify(request));
     });

--- a/lib/chromium/server.js
+++ b/lib/chromium/server.js
@@ -5,15 +5,12 @@ const ServerSocket = CC("@mozilla.org/network/server-socket;1",
                         "initSpecialConnection");
 
 const {Class} = require("sdk/core/heritage");
-
+const {prefs} = require("sdk/simple-prefs");
 const task = require("../util/task");
-
 const {Pool} = require("../devtools/server/protocol");
 const {DebuggerTransport, LocalDebuggerTransport} = require("../devtools/transport/transport");
 const DevToolsUtils = require("../devtools/toolkit/DevToolsUtils");
-
 const {ChromiumRootActor} = require("./root");
-
 
 var Connection = Class({
   extends: Pool,
@@ -30,12 +27,16 @@ var Connection = Class({
   },
 
   send: function(packet) {
-    console.log("SEND: " + JSON.stringify(packet, null, 2));
+    if (prefs["logDevToolsProtocolTraffic"]) {
+      console.log("<<<<<< Sent to devtools\n" + JSON.stringify(packet));
+    }
     this.transport.send(packet);
   },
 
   onPacket: task.async(function*(packet) {
-    console.log("RECV:" + JSON.stringify(packet, null, 2));
+    if (prefs["logDevToolsProtocolTraffic"]) {
+      console.log(">>>>>> Received from devtools\n" + JSON.stringify(packet));
+    }
     let actor = this.getActor(packet.to);
     if (!actor) {
       this.send({
@@ -150,7 +151,6 @@ function Listener(url) {
 
 Listener.prototype = {
   onSocketAccepted: DevToolsUtils.makeInfallible(function(socket, transport) {
-    console.log("Client connected.");
     let input = transport.openInputStream(0, 0, 0);
     let output = transport.openOutputStream(0, 0, 0);
     let dbgTransport = new DebuggerTransport(input, output);
@@ -160,9 +160,8 @@ Listener.prototype = {
     conn.root.sayHello();
     transport.ready();
   }, "Listener.onSocketAccepted"),
-  onStopListening: function(socket, status) {
-    console.log("onStopListening status: " + status);
-  },
+
+  onStopListening: function(socket, status) {}
 }
 
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -165,7 +165,6 @@ let action_button = ui.ActionButton({
 
 
 function tryConnect(url) {
-  console.log("trying to connect...");
   let transport = server.connect(url);
   let client = new DebuggerClient(transport);
   return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -10,5 +10,18 @@
   },
   "license": "MPL 2.0",
   "version": "0.0.1",
-  "main": "lib/main.js"
+  "main": "lib/main.js",
+  "preferences": [{
+    "name": "logDeviceProtocolTraffic",
+    "title": "Log the protocol traffic to and from the device",
+    "type": "bool",
+    "value": true,
+    "hidden": true
+  }, {
+    "name": "logDevToolsProtocolTraffic",
+    "title": "Log the protocol traffic to and from the toolbox",
+    "type": "bool",
+    "value": false,
+    "hidden": true
+  }]
 }


### PR DESCRIPTION
I was getting a bit tired of scrolling through huge amounts of logs, so I introduced 2 prefs that can be toggled to decide which logs you want to see: toolbox <-> devtools and devtools <-> device.
Most of time I'm interested in seeing the devtools <-> device traffic, so I turned this one on by default.

@past @jryans @jlongster let me know if something like this is useful to you.
