### PR TITLE
Delay getting stylesheets until the document is loaded (Fix #31)

### DIFF
--- a/lib/chromium/resource-store.js
+++ b/lib/chromium/resource-store.js
@@ -1,7 +1,6 @@
 var { Cu } = require("chrome");
 var { Class } = require("sdk/core/heritage");
 var { EventTarget } = require("sdk/event/target");
-var { emit } = require("sdk/event/core");
 var task = require("../util/task");
 Cu.importGlobalProperties(["URL"]);
 

--- a/lib/chromium/sheet-store.js
+++ b/lib/chromium/sheet-store.js
@@ -5,12 +5,17 @@ var task = require("../util/task");
 
 var CSSStore = Class({
   extends: EventTarget,
-  initialize: function(rpc) {
+
+  initialize(rpc) {
     EventTarget.prototype.initialize.call(this);
     this.rpc = rpc;
+    this.sheets = {};
+
+    this.navigatingPromise = Promise.resolve();
+
     this.rpc.on("CSS.styleSheetAdded", this.onStyleSheetAdded.bind(this));
     this.rpc.on("CSS.styleSheetRemoved", this.onStyleSheetRemoved.bind(this));
-    this.sheets = {};
+    this.rpc.on("Page.frameNavigated", this.onNavigated.bind(this));
   },
 
   init: task.async(function*() {
@@ -20,22 +25,6 @@ var CSSStore = Class({
     this.initialized = true;
 
     yield this.rpc.request("CSS.enable");
-
-    if (Object.keys(this.sheets).length < 1) {
-      // We don't appear to have received any onStyleSheetAdded messages.
-      // Maybe this is an earlier protocol version and we need getAllStyleSheets.
-      try {
-        let response = yield this.rpc.request("CSS.getAllStyleSheets", {});
-        if (response) {
-          for (let header of response.headers) {
-            this.onStyleSheetAdded({header: header});
-          }
-        }
-      } catch(e) {
-        console.error(e);
-      }
-    }
-
   }),
 
   destroy: task.async(function*() {
@@ -44,22 +33,51 @@ var CSSStore = Class({
     }
 
     this.initialized = false;
+
     yield this.rpc.request("CSS.disable");
   }),
 
-  getStyleSheets: function() {
-    return [for (key of Object.keys(this.sheets)) this.sheets[key]];
+  onNavigated(event) {
+    if (event.parentId) {
+      return;
+    }
+
+    // Create a promise that resolves only when the content is fully loaded so
+    // that the response to getStyleSheets can be delayed until we're sure to
+    // have all stylesheets.
+    this.navigatingPromise = new Promise((resolve, reject) => {
+      this.rpc.once("Page.domContentEventFired", resolve);
+    });
   },
 
-  get: function(styleSheetId) {
+  getStyleSheets: task.async(function*() {
+    yield this.navigatingPromise;
+
+    // Earlier protocol versions do not support styleSheetAdded events so we
+    // need to call getAllStyleSheets.
+    try {
+      let response = yield this.rpc.request("CSS.getAllStyleSheets", {});
+      if (response && response.headers.length) {
+        this.sheets = {};
+        for (let header of response.headers) {
+          this.onStyleSheetAdded({header});
+        }
+      }
+    } catch(e) {}
+
+    return [for (key of Object.keys(this.sheets)) this.sheets[key]];
+  }),
+
+  get(styleSheetId) {
     return this.sheets[styleSheetId];
   },
 
-  onStyleSheetAdded: function(params) {
+  onStyleSheetAdded(params) {
     this.sheets[params.header.styleSheetId] = params.header;
     emit(this, "style-sheet-added", params.header);
   },
-  onStyleSheetRemoved: function(params) {
+
+  onStyleSheetRemoved(params) {
     delete this.sheets[params.styleSheetId];
     emit(this, "style-sheet-removed", params.styleSheetId);
   }

--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -768,7 +768,8 @@ var ChromiumStyleSheetsActor = protocol.ActorClass({
   },
 
   getStyleSheets: asyncMethod(function*() {
-    return this.sheets.getStyleSheets().map((header, i) => {
+    let sheets = yield this.sheets.getStyleSheets();
+    return sheets.map((header, i) => {
       let ref = this.sheetRef(header);
       ref.styleSheetIndex = i;
       return ref;


### PR DESCRIPTION
Listing stylesheets is one of the things that behave very differently between chrome and safari. One protocol emits `stylesheet-added/removed` events, the other requires to call a `getAllStyleSheets` command. It would make sense to have feature detection and then have 2 `sheet-store` implementations, instead of trying to merge to very different approaches into one.

So the case where the devtools gets connected to the protocol after the page has loaded is simple, but when you reload the page, that's when problems start because we need to make sure we ask for the list stylesheets when they're actually available.
For instance, ios' `getAllStyleSheets` command will return an empty list if asked too early. And on chrome, there's no guarantee that the toolbox will ask for the list of stylesheets after all `stylesheet-added` events have been received. 

My plan for this fix was to delay responding to the style-editor panel until we're sure that all stylesheets are known.

I believe this would all be very much simpler if our style-editor would react to stylesheet added/removed events instead. This will happen with [bug 947119](https://bugzilla.mozilla.org/show_bug.cgi?id=947119). This way, we wouldn't need the panel to know when the page navigates, but instead, it would just be listening to new and removed stylesheets.

Anyway, here it is. At least we have something displayed in the style-editor when the page is reloaded.
