### PR TITLE
Fix #46 - Use handle.nodeName instead of handle.name for the doctype node name

### DIFF
--- a/lib/chromium/server.js
+++ b/lib/chromium/server.js
@@ -28,14 +28,14 @@ var Connection = Class({
 
   send: function(packet) {
     if (prefs["logDevToolsProtocolTraffic"]) {
-      console.log("<<<<<< Sent to devtools\n" + JSON.stringify(packet));
+      console.log("<<<<<< Sent to toolbox\n" + JSON.stringify(packet));
     }
     this.transport.send(packet);
   },
 
   onPacket: task.async(function*(packet) {
     if (prefs["logDevToolsProtocolTraffic"]) {
-      console.log(">>>>>> Received from devtools\n" + JSON.stringify(packet));
+      console.log(">>>>>> Received from toolbox\n" + JSON.stringify(packet));
     }
     let actor = this.getActor(packet.to);
     if (!actor) {

--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -68,7 +68,7 @@ var NodeActor = protocol.ActorClass({
       numChildren: this.handle.childNodeCount,
 
       // doctype attributes
-      name: this.handle.name,
+      name: this.handle.nodeName,
       publicId: this.handle.publicId,
       systemId: this.handle.systemId,
 


### PR DESCRIPTION
Contains an unrelated change to make console logging a bit clearer.
The actual fix was just changing `this.handle.name` to `this.handle.nodeName`.
