### PR TITLE
Make the inspector search actually suggest selectors

### DIFF
--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -294,7 +294,7 @@ var NodeListActor = protocol.ActorClass({
   }),
 
   items: method(function(start=0, end=this.nodeList.length) {
-    let nodes = this.nodeList.slice(start, end).map(item => this.walker._ref(item));
+    let nodes = this.nodeList.slice(start, end).map(item => this.walker.ref(item));
     let newParents = new Set();
     nodes.forEach(node => this.walker.ensurePathToRoot(node, newParents));
     return {
@@ -888,7 +888,79 @@ var ChromiumWalkerActor = protocol.ActorClass({
     }
   }),
 
-  getSuggestionsForQuery: todoMethod({
+  getActorsForSelector: function*(selector) {
+    let {nodeIds} = yield this.rpc.request("DOM.querySelectorAll", {
+      nodeId: this.root.handle.nodeId,
+      selector: selector
+    });
+    return nodeIds.map(id => this.refMap.get(id));
+  },
+
+  getSuggestionsForQuery: asyncMethod(function*(query, completing, selectorState) {
+    let suggestions = new Map();
+
+    if (selectorState === "class") {
+      for (let actor of yield this.getActorsForSelector(query || "[class]")) {
+        let classes = actor.getAttr("class");
+        if (classes) {
+          for (let className of classes.split(" ")) {
+            if (className.startsWith(completing)) {
+              suggestions.set("." + className,
+                              (suggestions.get("." + className)|0) + 1);
+            }
+          }
+        }
+      }
+    } else if (selectorState === "tag") {
+      for (let actor of yield this.getActorsForSelector(query || "*")) {
+        let tag = actor.handle.nodeName.toLowerCase();
+        if ((new RegExp("^" + completing + ".*", "i")).test(tag)) {
+          suggestions.set(tag, (suggestions.get(tag)|0) + 1);
+        }
+      }
+    } else if (selectorState === "id") {
+      for (let actor of yield this.getActorsForSelector(query || "[id]")) {
+        let id = actor.getAttr("id");
+        if (id && id.startsWith(completing)) {
+          suggestions.set("#" + id, 1);
+        }
+      }
+    } else if (selectorState === "null") {
+      for (let actor of yield this.getActorsForSelector(query)) {
+        let id = actor.getAttr("id");
+        if (id) {
+          suggestions.set("#" + id, 1);
+        }
+
+        let tag = actor.handle.nodeName.toLowerCase();
+        suggestions.set(tag, (suggestions.get(tag)|0) + 1);
+
+        let classes = actor.getAttr("class");
+        if (classes) {
+          for (let className of classes.split(" ")) {
+            suggestions.set("." + className,
+                            (suggestions.get("." + className)|0) + 1);
+          }
+        }
+      }
+    }
+
+    let result = [...suggestions];
+
+    // Sort alphabetically in increaseing order.
+    result = result.sort();
+    // Sort based on count in decreasing order.
+    result = result.sort(function(a, b) {
+      return b[1] - a[1];
+    });
+
+    result.slice(0, 25);
+
+    return {
+      query: query,
+      suggestions: result
+    };
+  }, {
     request: {
       query: Arg(0),
       completing: Arg(1),


### PR DESCRIPTION
This required to basically copy/paste `getSuggestionsForQuery` from the devtools walker actor into the chromium walker actor, adapting it so it goes via the device protocol instead.
I also took the opportunity to rewrite the function (got from 100+ lines to 60).
This seems to work well with both safari and chrome.

@campd can you take a look at this PR?
