### PR TITLE
Here's a comment about this one weird trick we use to know about nodes in the walker

### DIFF
--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -381,8 +381,13 @@ var ChromiumWalkerActor = protocol.ActorClass({
     // And iOS
     this.rpc.on("Inspector.inspect", this.onInspectorInspect.bind(this));
 
-    // Markup mutation events
+    // This is the event via which the actor receives handles for nodes.
+    // The protocol fires this event when the backend wants to provide us with
+    // the missing DOM structure for any given nodeId. This happens upon most of
+    // the calls requesting node ids.
     this.rpc.on("DOM.setChildNodes", this.onSetChildNodes.bind(this));
+
+    // Markup mutation events
     this.rpc.on("DOM.attributeRemoved", this.onAttributeRemoved.bind(this));
     this.rpc.on("DOM.attributeModified", this.onAttributeModified.bind(this));
     this.rpc.on("DOM.characterDataModified", this.onCharacterDataModified.bind(this));


### PR DESCRIPTION
I guess the comment makes sense, but I'd feel better if @campd would look at this.

I think the comment is required to help understand how this all works. I was a bit surprised at first to see that DOM.querySelectorAll would only return nodeIds, not handles, and even more surprised to see that our refmap would already contain handles for all these ids, even though these were deep nodes not displayed yet in the markup-view.
