### PR TITLE
Fix #41 - Makes the walker recognize iframe content documents as childnodes

### DIFF
--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -6,8 +6,7 @@ const protocol = require("../devtools-require")("devtools/server/protocol");
 const {asyncMethod, todoMethod, todoMethodSilent} = require("../util/protocol-extra");
 const {Actor, ActorClass, Pool, method, Arg, Option, RetVal, types, emit} = protocol;
 const {ChromiumPageStyleActor} = require("./styles");
-const {ChromiumHighlighterActor} = require("./highlighter");
-const {LongStringActor} = require("../devtools-require")("devtools/server/actors/string");
+const {LongStringActor} = require("../devtools/server/actors/string");
 const {getResourceStore} = require("./resource-store");
 Cu.importGlobalProperties(["URL"]);
 
@@ -64,7 +63,9 @@ var NodeActor = protocol.ActorClass({
       nodeType: this.handle.nodeType,
       namespaceURI: "http://www.w3.org/1999/xhtml",
       nodeName: this.handle.nodeName,
-      numChildren: this.handle.childNodeCount,
+      // If the node is a frame, it'll have a contentDocument handle property,
+      // which we need to consider as a child node.
+      numChildren: this.handle.contentDocument ? 1 : this.handle.childNodeCount,
 
       // doctype attributes
       name: this.handle.nodeName,
@@ -427,6 +428,11 @@ var ChromiumWalkerActor = protocol.ActorClass({
       this.updateChildren(ref, handle.children);
     }
 
+    // And if the handle is an iframe, make sure its contentDocument is returned.
+    if (handle.contentDocument) {
+      this.updateChildren(ref, [handle.contentDocument]);
+    }
+
     return ref;
   },
 
@@ -455,11 +461,7 @@ var ChromiumWalkerActor = protocol.ActorClass({
    * has the nodeId directly.
    */
   onInspectNodeRequested: function(params) {
-    let node = this.refMap.get(params.nodeId);
-    emit(this, "picker-node-picked", {
-      node: node,
-      newParents: [...this.ensurePathToRoot(node)]
-    });
+    emit(this, "picker-node-picked", this.attachElement(params.nodeId));
   },
 
   /**


### PR DESCRIPTION
In the chrome protocol, iframes do not have childNodes, they have a contentDocument property, and we need to use this as the node for the walker (and therefore the markupview) to walk into iframes.
