### PR TITLE
Fill the exception details when evaluating expressions that throw

### DIFF
--- a/lib/chromium/preview.js
+++ b/lib/chromium/preview.js
@@ -58,6 +58,10 @@ exports.generatePreview = function(handle, form, ctx) {
   for (var i = 0; i < previewOwn.length && i < OBJECT_PREVIEW_MAX_ITEMS; i++) {
     let originalProp = previewOwn[i];
     let prop = value.convertProperty(originalProp);
+    // XXX: getters and setters?
+    if (!prop.value) {
+      continue;
+    }
     prop.value = value.gripType.write(prop.value, ctx);
     previewData.ownProperties[originalProp.name] = prop;
   }

--- a/lib/chromium/webconsole.js
+++ b/lib/chromium/webconsole.js
@@ -175,20 +175,28 @@ var ChromiumConsoleActor = ActorClass({
 
     yield preview.loadPreview(this.rpc, response.result);
 
-    // XXX: exceptions.
+    let result, exception, exceptionMessage;
+    if (response.wasThrown) {
+      exception = response.result;
+      exceptionMessage = response.result.description;
+    } else {
+      result = response.result;
+    }
+
     return {
       input: expression,
       timestamp: Date.now(),
-      exception: null,
+      exception: exception,
+      exceptionMessage: exceptionMessage,
       helperResult: null,
-      result: response.result,
+      result: result,
     }
   }, {
     request: {
       text: Arg(0, "string")
     },
     response: RetVal(protocol.types.addDictType("chromium_evalJSResponse", {
-        result: "chromium_grip"
+        result: "nullable:chromium_grip"
     }))
   }),
 


### PR DESCRIPTION
Makes evaluating a bogus expression like foobarbaz display an informative error in the console, not a mysterious one in the terminal.
