### PR TITLE
Console log count doesn't update

### DIFF
--- a/lib/chromium/webconsole.js
+++ b/lib/chromium/webconsole.js
@@ -31,6 +31,8 @@ var ChromiumConsoleActor = ActorClass({
     this.rpc = tab.rpc;
 
     this.rpc.on("Console.messageAdded", this.onMessage.bind(this));
+    this.rpc.on("Console.messageRepeatCountUpdated",
+      this.onMessageCountUpdated.bind(this));
 
     this.enabledListeners = new Set();
     this.messageCache = {};
@@ -101,7 +103,15 @@ var ChromiumConsoleActor = ActorClass({
     if (!evt) {
       return;
     }
+
+    this.currentEvent = evt;
     this.cacheOrSend(evt.type, evt.payload);
+  },
+
+  onMessageCountUpdated: function(params) {
+    if (this.currentEvent) {
+      this.cacheOrSend(this.currentEvent.type, this.currentEvent.payload);
+    }
   },
 
   startListeners: asyncMethod(function*(listeners) {


### PR DESCRIPTION
This only logs "1" once for now:

```
for (var i = 0; i < 10; i ++) {
  console.log(1);
}
```

The upstream protocol sends a special event when the count of the lat log gets updated apparently.
Here's a tentative fix, but since I basically don't know the webconsole code at all, I would like to get @past's eyes on this PR before continuing any further.
