### PR TITLE
Scratchpad is rather picky about what value the exception property shall...

### DIFF
--- a/lib/chromium/webconsole.js
+++ b/lib/chromium/webconsole.js
@@ -174,7 +174,7 @@ var ChromiumConsoleActor = ActorClass({
 
     yield preview.loadPreview(this.rpc, response.result);
 
-    let result, exception, exceptionMessage;
+    let result, exception = null, exceptionMessage;
     if (response.wasThrown) {
       exception = response.result;
       exceptionMessage = response.result.description;


### PR DESCRIPTION
... have when evaluation was succeeesful.

Fixes issue #59.
