### PR TITLE
make error from todoMethod have the correct stack

### DIFF
--- a/lib/util/protocol-extra.js
+++ b/lib/util/protocol-extra.js
@@ -7,8 +7,9 @@ exports.asyncMethod = function(...args) {
 
 // Add a todo method that will throw an error when unimplemented.
 exports.todoMethod = function(spec) {
+  let err = new Error("This method is not yet implemented.");
   return method(function() {
-    throw new Error("This method is not yet implemented.")
+    throw err;
   }, spec);
 }
 


### PR DESCRIPTION
If we preemptively construct the error, it'll get the correct stack trace. I just saw a "not implemented" error but I had no way to trace back what actually was not implemented.

Now the stack will trace back to the actual function that isn't implemented yet.
