### PR TITLE
Revive Chrome Desktop via WebIDE, edit runtime labels

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,9 +33,22 @@ function onWebIDEWindowOpen(window) {
 
   let promise = window.promise;
 
+  /** Chrome Desktop **/
 
-  /** iOS device **/
+  let chromeDesktopRuntime = {
+    getName: function() {
+      return "Chrome Desktop";
+    },
+    connect: function(connection) {
+      let transport = server.connect("http://localhost:9222");
+      connection.connect(transport);
+      return promise.resolve();
+    },
+  };
 
+  AppManager.runtimeList.custom.push(chromeDesktopRuntime);
+
+  /** iOS Device **/
 
   // To find iOS devices, we need to use ios_webkit_debug_proxy (works on linux and windows).
   // On port 9221, we can find a list of connected devices.
@@ -47,7 +60,7 @@ function onWebIDEWindowOpen(window) {
 
   let iOSRuntime = {
     getName: function() {
-      return "iOS proxy";
+      return "iOS Proxy";
     },
     connect: function(connection) {
       iOSProxy.start();
@@ -55,16 +68,13 @@ function onWebIDEWindowOpen(window) {
       connection.connect(transport);
       return promise.resolve();
     },
-  }
+  };
 
   AppManager.runtimeList.custom.push(iOSRuntime);
 
-
-  /** Chrome on Android **/
-
+  /** Chrome Android **/
 
   let baseCustomRuntimes = AppManager.runtimeList.custom;
-
 
   function AndroidRuntime(id) {
     this._usbRuntime = new USBRuntime(id);
@@ -73,7 +83,7 @@ function onWebIDEWindowOpen(window) {
 
   AndroidRuntime.prototype = {
     getName: function() {
-      return "Google Chrome: " + this._usbRuntime.getName();
+      return "Chrome Android: " + this._usbRuntime.getName();
     },
     connect: function(connection) {
       let device = Devices.getByName(this._usbRuntime.id);
@@ -86,7 +96,7 @@ function onWebIDEWindowOpen(window) {
         connection.connect(transport);
       });
     },
-  }
+  };
 
   function scan() {
     AppManager.runtimeList.custom = [...baseCustomRuntimes];


### PR DESCRIPTION
My iOS bundle changes broke anyone who was using the "iOS proxy" option in WebIDE to connect to desktop Chrome.

So, this is all still terrible for now, but at least there is a new, more obvious option.

Also, I lightly edited the names of the runtimes.
