### PR TITLE
print out a maximum of 1000 chars when logging device messages

### DIFF
--- a/lib/chromium/rpc.js
+++ b/lib/chromium/rpc.js
@@ -45,9 +45,17 @@ var TabConnection = Class({
     this.socket.close();
   },
 
+  prepareOutput: function(output) {
+    if(prefs["logMessageThreshold"] > 0) {
+      return output.slice(0, prefs["logMessageThreshold"]);
+    }
+    return output;
+  },
+
   onMessage: function(evt) {
     if (prefs["logDeviceProtocolTraffic"]) {
-      console.log(">>>>>> Received from device\n" + evt.data);
+      console.log(">>>>>> Received from device\n" +
+                  this.prepareOutput(evt.data.toString()));
     }
     let packet = JSON.parse(evt.data);
     if ("id" in packet && this.outstandingRequests.has(packet.id)) {
@@ -72,7 +80,8 @@ var TabConnection = Class({
         params: params
       };
       if (prefs["logDeviceProtocolTraffic"]) {
-        console.log("<<<<<< Sent to device\n" + JSON.stringify(request));
+        console.log("<<<<<< Sent to device\n" +
+                    this.prepareOutput(JSON.stringify(request)));
       }
       this.outstandingRequests.set(request.id, { resolve: resolve, reject: reject });
       this.socket.send(JSON.stringify(request));

--- a/package.json
+++ b/package.json
@@ -29,5 +29,11 @@
     "type": "bool",
     "value": false,
     "hidden": true
+  }, {
+    "name": "logMessageThreshold",
+    "title": "Maximum amount of chars to print in log messages, 0 means no limit",
+    "type": "integer",
+    "value": 0,
+    "hidden": true
   }]
 }


### PR DESCRIPTION
What do you guys think about this? I hate when logging protocol traffic and you go to a page with huge sources and your terminal just fills up with garbage. Makes the logging useless. This truncates the messages to a 1000 char limit. Maybe we could make this a pref?
