### PR TITLE
don't precompile the kick script; instead to force the engine to pause just evaluate something

### DIFF
--- a/lib/chromium/thread.js
+++ b/lib/chromium/thread.js
@@ -378,10 +378,7 @@ var ChromiumThreadActor = ActorClass({
   onPaused: task.async(function*(params) {
     // If this is the pause kick, or a pause that happened after we asked
     // for a pause kick, return.
-    if (this.resuming || params.scriptId === this.kickPauseScript) {
-      this.resuming = false;
-      this.pauseOutstanding = false;
-      console.log("Kicking from resume");
+    if (this.resuming && this.pauseOutstanding) {
       yield this.rpc.request("Debugger.resume");
       return;
     }
@@ -486,15 +483,6 @@ var ChromiumThreadActor = ActorClass({
     yield this.rpc.request("Runtime.enable");
     yield this.rpc.request("Debugger.enable");
 
-    try {
-      let response = yield this.rpc.request("Debugger.compileScript", {
-        expression: "throw new Error('Kick')",
-        sourceURL: "about:firefox-resume-hack"
-      });
-      this.kickPauseScript = response.scriptId;
-    } catch(ex) {
-      console.error("Error compiling kick script.  This seems to happen on the iPad and I don't know why.");
-    }
     this.state = "attached";
     this.attaching = true;
     yield this.pseudoPause({
@@ -565,22 +553,28 @@ var ChromiumThreadActor = ActorClass({
     this.config.ignoreCaughtExceptions = options.ignoreCaughtExceptions;
 
     console.log("Resuming");
+    var wasKicked = false;
 
-    this.resuming = true;
     if (this.pauseOutstanding) {
-      console.log("Kicking the engine to clear out the pause request.");
+      this.resuming = true;
       yield this.updateExceptionState("all");
-      yield this.rpc.request("Debugger.runScript", {
-        scriptId: this.kickPauseScript
+      // The engine has a pause requested but doesn't actually pause
+      // until something happens. Evaluate a script to kick it into
+      // the pause state, and `onPaused` which simply resume from here
+      yield this.rpc.request("Runtime.evaluate", {
+        expression: "5"
       });
+      this.resuming = false;
       this.pauseOutstanding = false;
+      wasKicked = true;
     }
-    this.resuming = false;
 
     this.state = "running";
-
     yield this.updateExceptionState(this.getDesiredExceptionState());
-    yield this.rpc.request(resumeCommand);
+
+    if(!wasKicked) {
+      yield this.rpc.request(resumeCommand);
+    }
   }, {
     oneway: true,
     request: {


### PR DESCRIPTION
This technique seems to work more reliably. Instead of precompiling a script when attaching, and reusing that, just evaluate an expression directly. Various versions of webkit don't seem to support precompilation (no Debugger.compileScript). Here we just use Runtime.evaluate. In addition, this fixed a bug in Chrome because Chrome doesn't seem to reply with a packet when using `runScript`, at least sometimes.

Previously the debugger would be stuck in a paused state in startup, or easily get stuck in a weird state, depending on the device. This seems to make it behave rather well on iOS and Chrome.

Now I can get to the real stuff.
