### PR TITLE
Avoid undefined:undefined style properties when disabling styles

### DIFF
--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -177,10 +177,8 @@ var ChromiumPageStyleActor = protocol.ActorClass({
   }),
 
   propertyText: function(value) {
-    // XXX: important.
-    // I would like to clarify the previous comment: I meant "Handle
-    // important properties", not "This fixme comment is important".
-    if (!value) {
+    // XXX: Handle !important properties
+    if (!value || !value.name || !value.value) {
       return "";
     }
     let text = value.name + ":" + value.value;
@@ -200,13 +198,6 @@ var ChromiumPageStyleActor = protocol.ActorClass({
   },
 
   propertyTextRequestOld: function(rule, prop, range, value) {
-    if (!prop && !value) {
-      // unnecessary.
-      return;
-    }
-
-    let text = value ? value.name + ":" + value.value + ";" : "";
-
     return this.rpc.request("CSS.setPropertyText", {
       styleId: rule.style.styleId,
       propertyIndex: prop ? prop.index : 0,
@@ -369,7 +360,6 @@ var ChromiumPageStyleActor = protocol.ActorClass({
     let border = readQuad(model.border);
     let padding = readQuad(model.padding);
     let content = readQuad(model.content);
-
 
     let layout = {
       "width": model.width,
@@ -726,9 +716,11 @@ var ChromiumStyleRuleActor = protocol.ActorClass({
   modifyProperty: task.async(function*(mod) {
     let foundProp;
     this.style.cssProperties.forEach((prop, index) => {
-      prop.index = index;
       if (prop.name === mod.name) {
         foundProp = prop;
+        // The old CSS.setPropertyText implementation requires the property
+        // index to work, so let's set it here.
+        foundProp.index = index;
       }
     });
 
@@ -736,7 +728,6 @@ var ChromiumStyleRuleActor = protocol.ActorClass({
       if (foundProp && foundProp.value === mod.value) {
         return;
       }
-
 
       let range;
       if (foundProp && foundProp.range) {


### PR DESCRIPTION
Using the checkboxes in the rule-view to disable/enable properties actually creates new "undefined:undefined;" properties every time.
This change should hopefully fix this problem.

I also took the opportunity to look at why !important properties were not always handled correctly, but any fix I attempted lead to crazy range fix-up assertion errors.
I understand why we need to deal with ranges, but wasn't able to fully grasp the logic of the updateRange and adjustPoint functions while working on this bug.
A little guidance would be great.
