### PR TITLE
Removing range fixups altogether ... can this work?

### DIFF
--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -109,9 +109,6 @@ var ChromiumPageStyleActor = protocol.ActorClass({
     return actor;
   },
 
-  /**
-   * I truly hate this method.
-   */
   setPropertyText: task.async(function*(rule, prop, value={}) {
     // If this is updating an existing property, provide the range of that
     // property so it can be replaced. Otherwise define an empty range for the


### PR DESCRIPTION
⚠ DO NOT MERGE YET ⚠

I'm filing this PR for discussing our need of range fixups.
The change here basically just removes everything that has to do with updating ranges in our actors.
We already have code that updates a rule actor's css properties when they change (`updateStyleRef`). This has the effect of updating all `cssProperties` in a `ChromiumStyleRuleActor` to make sure they are up to date.
Also, the only place in the code where we actually need ranges is in `setPropertyTextRequestNew` when we call:

```
    return this.rpc.request("CSS.setPropertyText", {
      styleSheetId: rule.style.styleSheetId,
      range: range,
      text: this.buildPropertyTextValue(value)
    });
```

But the `range` passed here actually comes from the property which text is being updated. And this property's range is bound to be correct, because `updateStyleRef` updates it whenever necesssary.

@campd what do you think? Am I missing something obvious? As far as I was able to manually test, I couldn't see anything really badly broken with this patch.
