### PR TITLE
fix will-navigate events when navigating to a different URL

### DIFF
--- a/lib/chromium/root.js
+++ b/lib/chromium/root.js
@@ -159,7 +159,6 @@ var ChromiumTabActor = ActorClass({
     this.json = json;
     this.rpc = rpc.TabConnection(json);
 
-    this.rpc.on("Page.frameStartedLoading", this.onFrameStartedLoading.bind(this));
     this.rpc.on("Page.frameNavigated", this.onPageNavigated.bind(this));
 
     this.consoleActorID = conn.manageLazy(this, conn.allocID(), () => {
@@ -188,20 +187,18 @@ var ChromiumTabActor = ActorClass({
     }
   },
 
-  onFrameStartedLoading: task.async(function*(params) {
-    if (params.frameId != this.rootFrameId) {
-      return;
-    }
-
-    emit(this, "tab-navigated", this.currentURL, "start");
-  }),
-
   onPageNavigated: function(params) {
     // XXX: We only send tabNavigated for toplevel frame loads.
     // Which is a weakness of the fxdevtools protocol, look in to that.
     if (params.frame.parentId) {
       return;
     }
+
+    // XXX: send the start event here because I don't know how to get
+    // the start even of only the top-level page.
+    // `frameStartedLoading` is the right event but there's no way to
+    // detect that it's the top-level page.
+    emit(this, "tab-navigated", this.currentURL, "start");
 
     this.rootFrameId = params.frame.id;
     this.currentURL = params.frame.url;


### PR DESCRIPTION
I'm not entirely sure about this, but looking through the frontend it looks like the timing of the `will-navigate` and `navigate` events are mainly for tests. Right now `will-navigate` is not fired when changing the URL of the page (it works when just reloading, because the top-level frame id is the same). This may fix other obscure bugs that we are seeing. However, the timing is wrong; `will-navigate` now fires after the navigation actually happens... but at least it fires.

The problem is that in `onFrameStartedLoading` we have no way to detect if it's a top-level page or not, and we only want to send these events for top-level pages.
