### PR TITLE
Switch to new WebIDE runtime API (bug 1069552)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,6 @@ const {Cu} = require("chrome");
 const unload = require("sdk/system/unload");
 
 const {DebuggerClient} = Cu.import("resource://gre/modules/devtools/dbg-client.jsm",  {});
-const {Devices} = Cu.import("resource://gre/modules/devtools/Devices.jsm");
 let {gDevTools} = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
 let {devtools} = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
 Cu.import("resource://gre/modules/Services.jsm");
@@ -13,112 +12,10 @@ const task = require("./util/task");
 const server = require("./chromium/server");
 const timers = require("sdk/timers");
 const { notify } = require("sdk/notifications");
+const scanner = require("./util/scanner");
 
-const {ConnectionManager} = devtools.require("devtools/client/connection-manager");
-const {USBRuntime} = devtools.require("devtools/webide/runtimes");
-const {AppManager} = devtools.require("devtools/webide/app-manager");
-
-let winObserver = function(win, topic) {
-  if (topic == "domwindowopened") {
-    win.addEventListener("load", function onLoadWindow() {
-      win.removeEventListener("load", onLoadWindow, false);
-      if (win.document.documentURI == "chrome://webide/content/webide.xul") {
-        win.setTimeout(() => onWebIDEWindowOpen(win), 0);
-      }
-    }, false);
-  }
-}
-Services.ww.registerNotification(winObserver);
-
-let webIDEWindow = Services.wm.getMostRecentWindow("devtools:webide");
-if (webIDEWindow) {
-  onWebIDEWindowOpen(webIDEWindow);
-}
-
-function onWebIDEWindowOpen(window) {
-
-  let promise = window.promise;
-
-  let runtimesToRestore = [...AppManager.runtimeList.custom];
-
-  /** iOS device **/
-
-
-  // To find iOS devices, we need to use ios_webkit_debug_proxy (works on linux and windows).
-  // On port 9221, we can find a list of connected devices.
-  // I believe we should build a static version of ios_webkit_debug_proxy
-  // and integrate it in the ADB Addon Helper.
-  //
-  // At the moment, we just assume that a device is plugged and that ios_webkit_debug_proxy
-  // is runnning.
-
-  let iOSRuntime = {
-    getName: function() {
-      return "iOS proxy";
-    },
-    connect: function(connection) {
-      let transport = server.connect("http://localhost:9222");
-      connection.connect(transport);
-      return promise.resolve();
-    },
-  }
-
-  AppManager.runtimeList.custom.push(iOSRuntime);
-
-
-  /** Chrome on Android **/
-
-
-  let baseCustomRuntimes = AppManager.runtimeList.custom;
-
-
-  function AndroidRuntime(id) {
-    this._usbRuntime = new USBRuntime(id);
-    this._usbRuntime.updateNameFromADB().then( () => AppManager.update("runtimelist"));
-  }
-
-  AndroidRuntime.prototype = {
-    getName: function() {
-      return "Google Chrome: " + this._usbRuntime.getName();
-    },
-    connect: function(connection) {
-      let device = Devices.getByName(this._usbRuntime.id);
-      let freeLocalPort = ConnectionManager.getFreeTCPPort();
-      let local = "tcp:" + freeLocalPort;
-      let remote = "localabstract:chrome_devtools_remote";
-
-      return device.forwardPort(local, remote).then(() => {
-        let transport = server.connect("http://localhost:" + freeLocalPort);
-        connection.connect(transport);
-      });
-    },
-  }
-
-  function scan() {
-    AppManager.runtimeList.custom = [...baseCustomRuntimes];
-    AppManager.update("runtimelist");
-    for (let id of Devices.available()) {
-      let device = Devices.getByName(id);
-      device.shell("grep -q chrome_devtools_remote /proc/net/unix && echo OK || echo KO").then(stdout => {
-        if (stdout.match(/^OK/)) {
-          AppManager.runtimeList.custom.push(new AndroidRuntime(id));
-          AppManager.update("runtimelist");
-        }
-      });
-    }
-  }
-
-  Devices.on("unregister", scan);
-  Devices.on("register", scan);
-  scan();
-  unload.when(function () {
-    AppManager.runtimeList.custom = runtimesToRestore;
-    AppManager.update("runtimelist");
-    Devices.off("unregister", scan);
-    Devices.off("register", scan);
-  });
-}
-
+// Add runtime entries to WebIDE
+scanner.register();
 
 var openToolbox = task.async(function*(client, form, hostOptions, options={}) {
   let tool = options.tool;
@@ -325,6 +222,5 @@ var commands = [
 gcli.addItems(commands);
 
 unload.when(function () {
-  Services.ww.unregisterNotification(winObserver);
   gcli.removeItems(commands);
 });

--- a/lib/util/scanner.js
+++ b/lib/util/scanner.js
@@ -1,0 +1,160 @@
+const { Cu } = require("chrome");
+const { devtools } =
+  Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+const EventEmitter = devtools.require("devtools/toolkit/event-emitter");
+const task = require("./task");
+const { when: unload } = require("sdk/system/unload");
+const { ConnectionManager } =
+  devtools.require("devtools/client/connection-manager");
+const { Devices } =
+  Cu.import("resource://gre/modules/devtools/Devices.jsm", {});
+const Runtimes = devtools.require("devtools/webide/runtimes");
+const server = require("../chromium/server");
+
+let Scanner = {
+
+  _runtimes: [],
+
+  enable: function() {
+    this._updateRuntimes = this._updateRuntimes.bind(this);
+    Devices.on("register", this._updateRuntimes);
+    Devices.on("unregister", this._updateRuntimes);
+    Devices.on("addon-status-updated", this._updateRuntimes);
+    this._updateRuntimes();
+  },
+
+  disable: function() {
+    Devices.off("register", this._updateRuntimes);
+    Devices.off("unregister", this._updateRuntimes);
+    Devices.off("addon-status-updated", this._updateRuntimes);
+  },
+
+  _emitUpdated: function() {
+    this.emit("runtime-list-updated");
+  },
+
+  _updateRuntimes: function() {
+    if (this._updatingPromise) {
+      return this._updatingPromise;
+    }
+    this._runtimes = [];
+    this._addStaticRuntimes();
+    let promises = [];
+    for (let id of Devices.available()) {
+      let device = Devices.getByName(id);
+      promises.push(this._detectAdbRuntimes(device));
+    }
+    this._updatingPromise = Promise.all(promises);
+    this._updatingPromise.then(() => {
+      this._emitUpdated();
+      this._updatingPromise = null;
+    }, () => {
+      this._updatingPromise = null;
+    });
+    return this._updatingPromise;
+  },
+
+  _addStaticRuntimes: function() {
+    this._runtimes.push(iOSRuntime);
+  },
+
+  _detectAdbRuntimes: task.async(function*(device) {
+    let model;
+    if (device.getModel) {
+      model = yield device.getModel();
+    }
+    let detectedRuntimes = yield ChromeOnAndroidRuntime.detect(device, model);
+    this._runtimes.push(...detectedRuntimes);
+  }),
+
+  scan: function() {
+    return this._updateRuntimes();
+  },
+
+  listRuntimes: function() {
+    return this._runtimes;
+  }
+
+};
+
+EventEmitter.decorate(Scanner);
+
+// TODO: Separate Chrome Desktop out of here once we have iOS proxy built-in
+var iOSRuntime = {
+  type: Runtimes.RuntimeTypes.OTHER,
+  connect: function(connection) {
+    let transport = server.connect("http://localhost:9222");
+    connection.connect(transport);
+    return Promise.resolve();
+  },
+  get id() {
+    return "ios";
+  },
+  get name() {
+    return "Safari on iOS / Chrome Desktop";
+  },
+};
+
+function AdbRuntime(device, model, socketType, socketPath) {
+  this.device = device;
+  this._model = model;
+  this._socketType = socketType;
+  this._socketPath = socketPath;
+}
+
+AdbRuntime.prototype = {
+  type: Runtimes.RuntimeTypes.USB,
+  connect: function(connection) {
+    let port = ConnectionManager.getFreeTCPPort();
+    let local = "tcp:" + port;
+    let remote = this._socketType + ":" + this._socketPath;
+    return this.device.forwardPort(local, remote).then(() => {
+      let transport = server.connect("http://localhost:" + port);
+      connection.connect(transport);
+    });
+  },
+  get id() {
+    return this.device.id + "|" + this._socketPath;
+  },
+};
+
+function ChromeOnAndroidRuntime(device, model) {
+  AdbRuntime.call(this, device, model, "localabstract",
+                  "chrome_devtools_remote");
+}
+
+ChromeOnAndroidRuntime.detect = task.async(function*(device, model) {
+  let runtimes = [];
+  let query = "grep -q chrome_devtools_remote /proc/net/unix; echo $?";
+  let reply = yield device.shell(query);
+  // XXX: Sometimes we get an empty response back.  Likely a bug in our shell
+  // code in ADB Helper.
+  while (reply.length != 3) {
+    reply = yield device.shell(query);
+  }
+  if (reply === "0\r\n") {
+    let runtime = new ChromeOnAndroidRuntime(device, model);
+    console.log("Found " + runtime.name);
+    runtimes.push(runtime);
+  }
+  return runtimes;
+});
+
+ChromeOnAndroidRuntime.prototype = Object.create(AdbRuntime.prototype);
+
+Object.defineProperty(ChromeOnAndroidRuntime.prototype, "name", {
+  get: function() {
+    return "Chrome on Android (" + (this._model || this.device.id) + ")";
+  }
+});
+
+exports.register = function() {
+  // Only register our |Scanner| if the API exists
+  if (Runtimes && Runtimes.RuntimeScanners) {
+    // Add our scanner
+    Runtimes.RuntimeScanners.add(Scanner);
+    unload(() => {
+      Runtimes.RuntimeScanners.remove(Scanner);
+    });
+  }
+};


### PR DESCRIPTION
This uses a new WebIDE API to cleanly add new runtimes, instead of hacking up random objects as before.

The API itself has not yet landed, so you'd need patches from bug 1069552 for now. I plan to uplift this work for Dev Edition too.

The changes in this add-on are currently **backwards incompatible**, so you would need an updated Firefox build after this. If this seems bad to someone, please speak up! I was hoping to just trash the old code, but perhaps people feel we need to keep it around.

I won't attempt to merge this change until the API lands in Nightly.
