### PR TITLE
Implement getMatchedSelectors and filter computedview styles.

### DIFF
--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -669,7 +669,14 @@ var ChromiumStyleSheetActor = protocol.ActorClass({
     }
   }, "getOriginalSources"),
 
-  getOriginalLocation: todoMethod({
+  getOriginalLocation: method(function(line, column) {
+    // XXX return original location for source maps
+    return {
+      line: line,
+      column: column,
+      source: this.header.sourceURL
+    }
+  }, {
     request: {
       line: Arg(0, "number"),
       column: Arg(1, "number")
@@ -679,7 +686,7 @@ var ChromiumStyleSheetActor = protocol.ActorClass({
       line: "number",
       column: "number"
     }))
-  }, "getOriginalLocation"),
+  }),
 
   getMediaRules: todoMethod({
     request: {},


### PR DESCRIPTION
This implements the todoMethod getMatchedSelectors so that it's possible to expand the computed style properties.

Also refactors the getComputed method so that it doesn't always return all the computed styles, but only those which actually apply.

While working on this I discovered a problem when checking the "browser styles" checkbox on and off. This can't be fixed in this addon alone and requires changes on the devtools toolbox side. See issue #83 
