### PR TITLE
Make it possible to name todoMethods for easier debugging

### DIFF
--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -243,7 +243,7 @@ var ChromiumPageStyleActor = protocol.ActorClass({
       sheets: "array:chromium_stylesheet",
       matched: "array:chromium_matchedselector"
     }))
-  }),
+  }, "getMatchedSelectors"),
 
   getApplied: asyncMethod(function*(node, options) {
     let result = {
@@ -507,7 +507,7 @@ var ChromiumStyleSheetActor = protocol.ActorClass({
 
   toggleDisabled: todoMethod({
     response: { disabled: RetVal("boolean")}
-  }),
+  }, "toggleDisabled"),
 
   getText: asyncMethod(function*() {
     let response = yield this.rpc.request("CSS.getStyleSheetText", {
@@ -525,7 +525,7 @@ var ChromiumStyleSheetActor = protocol.ActorClass({
     response: {
 //      originalSources: RetVal("nullable:array:originalsource")
     }
-  }),
+  }, "getOriginalSources"),
 
   getOriginalLocation: todoMethod({
     request: {
@@ -537,14 +537,14 @@ var ChromiumStyleSheetActor = protocol.ActorClass({
       line: "number",
       column: "number"
     }))
-  }),
+  }, "getOriginalLocation"),
 
   getMediaRules: todoMethod({
     request: {},
     response: {
 //      mediaRules: RetVal("nullable:array:mediarule")
     }
-  }),
+  }, "getMediaRules"),
 
   update: asyncMethod(function*(text, transition) {
     yield this.rpc.request("CSS.setStyleSheetText", {
@@ -751,7 +751,7 @@ var ChromiumStyleRuleActor = protocol.ActorClass({
   modifySelector: todoMethod({
     request: { selector: Arg(0, "string") },
     response: { isModified: RetVal("boolean") },
-  }),
+  }, "modifySelector"),
 });
 
 // XXX: Don't do the media change actor yet.

--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -235,7 +235,7 @@ var NodeActor = protocol.ActorClass({
   getEventListenerInfo: todoMethod({
     request: {},
     response: { events: RetVal("json") }
-  }),
+  }, "getEventListenerInfo"),
 
   modifyAttributes: asyncMethod(function*(modifications) {
     for (let mod of modifications) {
@@ -259,7 +259,7 @@ var NodeActor = protocol.ActorClass({
   getFontFamilyDataURL: todoMethod({
     request: {font: Arg(0, "string"), fillStyle: Arg(1, "nullable:string")},
     response: RetVal("chromium_imageData")
-  })
+  }, "getFontFamilyDataURL")
 });
 
 
@@ -1047,11 +1047,11 @@ var ChromiumWalkerActor = protocol.ActorClass({
 
   hideNode: todoMethod({
     request: { node: Arg(0, "chromium_domnode") }
-  }),
+  }, "hideNode"),
 
   showNode: todoMethod({
     request: { node: Arg(0, "chromium_domnode") }
-  }),
+  }, "showNode"),
 
   innerHTML: asyncMethod(function*(node) {
     // XXX: The protocol doesn't support getInnerHTML, so use the outerHTML,
@@ -1124,7 +1124,7 @@ var ChromiumWalkerActor = protocol.ActorClass({
       sibling: Arg(2, "nullable:chromium_domnode")
     },
     response: {}
-  }),
+  }, "insertBefore"),
 
   getMutations: method(function(options={}) {
     let pending = this.pendingMutations || [];
@@ -1147,7 +1147,7 @@ var ChromiumWalkerActor = protocol.ActorClass({
   isInDOMTree: todoMethod({
     request: { node: Arg(0, "chromium_domnode") },
     response: { attached: RetVal("boolean") }
-  }),
+  }, "isInDOMTree"),
 
   getNodeActorFromObjectActor: todoMethod({
     request: {
@@ -1156,7 +1156,7 @@ var ChromiumWalkerActor = protocol.ActorClass({
     response: {
       nodeFront: RetVal("nullable:chromium_disconnectedNode")
     }
-  }),
+  }, "getNodeActorFromObjectActor"),
 
   getStyleSheetOwnerNode: todoMethod({
     request: {
@@ -1165,8 +1165,6 @@ var ChromiumWalkerActor = protocol.ActorClass({
     response: {
       ownerNode: RetVal("nullable:chromium_disconnectedNode")
     }
-  }),
+  }, "getStyleSheetOwnerNode"),
 });
 exports.ChromiumWalkerActor = ChromiumWalkerActor;
-
-

--- a/lib/util/protocol-extra.js
+++ b/lib/util/protocol-extra.js
@@ -6,10 +6,11 @@ exports.asyncMethod = function(...args) {
 }
 
 // Add a todo method that will throw an error when unimplemented.
-exports.todoMethod = function(spec) {
-  let err = new Error("This method is not yet implemented.");
+exports.todoMethod = function(spec, methodName) {
   return method(function() {
-    throw err;
+    let msg = methodName ? "Method " + methodName : "A method";
+    msg += " on actor " + this.typeName + " is not yet implemented";
+    throw new Error(msg);
   }, spec);
 }
 


### PR DESCRIPTION
It's not always obvious which method is the missing one when reading the logs (todoMethod throws an error in the console).
This helps.

It only adds an optional 2nd argument to todoMethod that, if passed, will be used to output a better error message to the console.
It also prints the actor typename in the error message.
