### PR TITLE
Make the box-model layout-view work with ios

### DIFF
--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -340,12 +340,7 @@ var ChromiumPageStyleActor = protocol.ActorClass({
     }))
   }),
 
-  getLayout: asyncMethod(function*(node) {
-    // XXX: This request isn't compatible with the IOS protocol
-    response = yield this.rpc.request("DOM.getBoxModel", {
-      nodeId: node.handle.nodeId,
-    });
-
+  getLayoutFromBoxModel: function(model) {
     function readQuad(quad) {
       return {
         TL: { x: quad[0], y: quad[1] },
@@ -355,7 +350,6 @@ var ChromiumPageStyleActor = protocol.ActorClass({
       }
     }
 
-    let model = response.model;
     let margin = readQuad(model.margin);
     let border = readQuad(model.border);
     let padding = readQuad(model.padding);
@@ -381,6 +375,60 @@ var ChromiumPageStyleActor = protocol.ActorClass({
     layout.autoMargins = {};
 
     return layout;
+  },
+
+  getLayoutFromComputedStyle: function*(node, computedStyle) {
+    let layout = {};
+
+    // Determine the content box width and height
+    let properties = yield node.callFunction(
+      "function() {return this.getBoundingClientRect()}");
+    properties.forEach(({name, value}) => {
+      if (name === "width" || name === "height") {
+        layout[name] = Math.round(value.value);
+      }
+    });
+
+    for (let prop of [
+      "position",
+      "margin-top",
+      "margin-right",
+      "margin-bottom",
+      "margin-left",
+      "padding-top",
+      "padding-right",
+      "padding-bottom",
+      "padding-left",
+      "border-top-width",
+      "border-right-width",
+      "border-bottom-width",
+      "border-left-width"
+    ]) {
+      layout[prop] = getComputedStyleValue(computedStyle, prop);
+    }
+
+    // XXX: auto margins.
+    layout.autoMargins = {};
+
+    return layout;
+  },
+
+  getLayout: asyncMethod(function*(node) {
+    // iOS doesn't support the DOM.getBoxModel request, so on iOS we use
+    // getComputedStyleForNode (which is what WebkitInspector does too).
+    try {
+      let response = yield this.rpc.request("DOM.getBoxModel", {
+        nodeId: node.handle.nodeId,
+      });
+
+      return this.getLayoutFromBoxModel(response.model);
+    } catch (e) {
+      let response = yield this.rpc.request("CSS.getComputedStyleForNode", {
+        nodeId: node.handle.nodeId
+      });
+
+      return yield this.getLayoutFromComputedStyle(node, response.computedStyle);
+    }
   }, {
     request: {
       node: Arg(0, "chromium_domnode"),
@@ -809,3 +857,12 @@ var ChromiumStyleSheetsActor = protocol.ActorClass({
   })
 });
 exports.ChromiumStyleSheetsActor = ChromiumStyleSheetsActor;
+
+function getComputedStyleValue(computedStyle, propertyName) {
+  for (let {name, value} of computedStyle) {
+    if (propertyName === name) {
+      return value;
+    }
+  }
+  return "";
+}

--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -259,7 +259,35 @@ var NodeActor = protocol.ActorClass({
   getFontFamilyDataURL: todoMethod({
     request: {font: Arg(0, "string"), fillStyle: Arg(1, "nullable:string")},
     response: RetVal("chromium_imageData")
-  }, "getFontFamilyDataURL")
+  }, "getFontFamilyDataURL"),
+
+  /**
+   * Execute any function declaration with 'this' being the current node.
+   * @param {String} functionDeclaration A function declaration string which
+   * will be executed. In this function, 'this' will be the DOM node.
+   * @param {Array} functionArgs Optional array of arguments for the function.
+   * @return {Array} An array of properties for the returned object
+   */
+  callFunction: task.async(function*(functionDeclaration, functionArgs=[]) {
+    // Get the runtime object for this dom node
+    response = yield this.rpc.request("DOM.resolveNode", {
+      nodeId: this.handle.nodeId
+    });
+
+    // Execute the function on the resolved runtime object
+    response = yield this.rpc.request("Runtime.callFunctionOn", {
+      objectId: response.object.objectId,
+      functionDeclaration: functionDeclaration,
+      arguments: functionArgs
+    });
+
+    // Get all the properties from the returned object
+    response = yield this.rpc.request("Runtime.getProperties", {
+      objectId: response.result.objectId
+    });
+
+    return response.result;
+  })
 });
 
 


### PR DESCRIPTION
On firefox, we're using getBoundingClientRect + computed style to determine the width/height + margin/padding/border.

On chrome, we're using the `DOM.getBoxModel` command and then transform the returned quads in something that our layout-view can understand.

On ios, this command doesn't exist, so instead, we fall back to doing the same as on firefox:
- getting the bounding rect (by executing js code on the node, see https://github.com/campd/fxdt-adapters/wiki/Executing-random-code-on-a-DOM-node)
- getting the computed style (by using the `CSS.getComputedStyleForNode` command).
