### PR TITLE
better source listing & minor fixes

### DIFF
--- a/lib/chromium/resource-store.js
+++ b/lib/chromium/resource-store.js
@@ -8,8 +8,13 @@ Cu.importGlobalProperties(["URL"]);
  * Removes the hash from a URL.
  */
 function normalize(url) {
-  url = new URL(url);
-  return url.protocol + "//" + url.host + url.pathname + url.search;
+  try {
+    url = new URL(url);
+    return url.protocol + "//" + url.host + url.pathname + url.search;
+  } catch (e) {
+    // Leave invalid URLs unchanged
+    return url;
+  }
 }
 exports.normalize = normalize;
 

--- a/lib/chromium/thread.js
+++ b/lib/chromium/thread.js
@@ -107,7 +107,11 @@ var FrameActor = ActorClass({
     let form = {
       actor: this.actorID,
       type: "call",
-      this: this.frameThis.form(null, this.thread.pauseActor),
+      // If `frameThis` is not an ObjectGrip, it won't have a form and
+      // needs to be passed directly (e.g. { type: "undefined" }).
+      this: (this.frameThis.form ?
+             this.frameThis.form(null, this.thread.pauseActor) :
+             this.frameThis),
       // The specification calls for this to be a grip, but it ain't easy
       // to get with chrome.
       callee: {
@@ -353,7 +357,15 @@ var ChromiumThreadActor = ActorClass({
 
     this.state = "detached";
     this.options = {};
+
+    // _sources is a map of url to SourceActor. _rawScripts is a
+    // map of script id to script info and is internally used to keep
+    // track of existing scripts, while _sources is blown away and
+    // rebuilt based off of _rawScripts in events like reconfigure
+    // (v8 doesn't have a method to get a list of sources)
     this._sources = new Map();
+    this._rawScripts = new Map();
+
     this._breakpoints = new Map();
     this.scriptSources = new Map();
     this.stack = new Stack(this);
@@ -384,6 +396,10 @@ var ChromiumThreadActor = ActorClass({
       return;
     }
     let source = this.sourceRef(params.url, params);
+    this._rawScripts.set(params.scriptId, {
+      url: params.url,
+      scriptId: params.scriptId
+    });
     emit(this, "new-source", source);
   },
 
@@ -409,7 +425,7 @@ var ChromiumThreadActor = ActorClass({
 
   onTabNavigated: function(url, state) {
     if(state === 'start') {
-      this.clearSources();
+      this.clearSources({ hard: true });
     }
   },
 
@@ -479,9 +495,14 @@ var ChromiumThreadActor = ActorClass({
     emit(this, "resumed");
   },
 
-  clearSources: function() {
-    console.log('clearSources');
+  clearSources: function(opts = {}) {
     this._sources = new Map();
+
+    // Doing a hard clear means that we want to even blow away our
+    // internal list of script ids
+    if(opts.hard) {
+      this._rawScripts = new Map();
+    }
   },
 
   reconfigure: method(function(options = {}) {
@@ -609,6 +630,10 @@ var ChromiumThreadActor = ActorClass({
   }),
 
   sources: method(function() {
+    for(let script of this._rawScripts.values()) {
+      this.sourceRef(script.url, script);
+    }
+
     return this._sources.values();
   }, {
     request: {},


### PR DESCRIPTION
This is a continuation of https://github.com/campd/fxdt-adapters/pull/81 (coming from master now, had to open a new PR)

This makes the source listing a lot more reliable. It will clear when navigating across pages, and you'll get the right source list back after a `reconfigure` which clears the list. This also makes it you'll always see the sources when the debugger first loads.

There's a few other small fixes in here too for dealing with bad URLs and frames with an undefined `this`. Been testing mostly on Chrome but will thoroughly test on iOS now.
