### PR TITLE
Display page errors in the web console

### DIFF
--- a/lib/chromium/webconsole.js
+++ b/lib/chromium/webconsole.js
@@ -14,7 +14,8 @@ types.addDictType("chromium_consolemsg", {
   // XXX: Figure out objects.
 });
 types.addDictType("chromium_pageerror", {
-  "errorMessage": "longstring",
+  // XXX: should be longstring, but it doesn't get properly marshalled on reload
+  "errorMessage": "string",
 });
 
 var ChromiumConsoleActor = ActorClass({


### PR DESCRIPTION
Fixes issues #55 and #100 and also corrects the timestamps for console API messages.

One potentially confusing bit is that network-related errors appear to belong in the JS category, but this is a side-effect of the very specific type of network events we display for Gecko. These are not regular logs of network transfers, but plain error messages when things break. I don't believe we have any similar messages in Gecko, but if we do, I bet they end up in the JS category as well.

When I get to add support for network traffic, I may revisit this, but it seems useful to display errors separately from traffic data, as the latter can be overwhelming and therefore disabled.
