### PR TITLE
Enable the DOM agent so Valence can start properly with Chrome canary

### DIFF
--- a/lib/chromium/root.js
+++ b/lib/chromium/root.js
@@ -215,6 +215,13 @@ var ChromiumTabActor = ActorClass({
    */
   attach: asyncMethod(function*() {
     yield this.rpc.request("Inspector.enable");
+    // The DOM agent should also be enabled at this stage. Chrome > 39 requires
+    // it when the CSSStore is initialized.
+    try {
+      yield this.rpc.request("DOM.enable");
+    } catch (e) {
+      // This fails on ios, but ios doesn't require the agent to be enabled.
+    }
 
     this.resources = resources.getResourceStore(this.rpc);
     this.sheets = sheets.getCSSStore(this.rpc);


### PR DESCRIPTION
Fixes issue #94 which prevented debugging chrome canary (I think > 39, but it could be 40).
Something changed in the chrome protocol so that it's now mandatory to enable the DOM agent (requesting `"CSS.enable"` complained about it).
I added the code to root.js because that's where the CSS Sheet store is initialized, and we also need the DOM agent to be enabled in the walker, so I figured let's enable it once and for all from the start.
The whole thing is try/catched because the call is only necessary on canary and fails on other devices/browsers.
