### PR TITLE
fix debugger breakpoints with latest changes in Firefox

### DIFF
--- a/lib/chromium/thread.js
+++ b/lib/chromium/thread.js
@@ -120,6 +120,7 @@ var FrameActor = ActorClass({
       },
       depth: this.depth,
       where: location,
+      source: source ? source.form() : { url: 'internal' },
       environment: this.environment.form(this.thread.pauseActor)
     };
 


### PR DESCRIPTION
This should fix breakpoints with the Debugger.Source changes
