### PR TITLE
Require at least 1 tab for GCLI.  Fixes #113.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -84,7 +84,7 @@ function tryConnect(url) {
   return new Promise((resolve, reject) => {
     client.connect((type, traits) => {
       client.listTabs(response => {
-        if (response.error) {
+        if (response.error || response.tabs.length === 0) {
           client.close();
           reject(response);
         } else {
@@ -209,14 +209,14 @@ var commands = [
     description: 'Check remotely on Safari (iOS)',
     exec: function(args, context) {
       return debugIOS(context.environment.chromeWindow, context.environment.window);
-    }    
+    }
   },
   {
     name: 'android',
     description: 'Check on remotely on Android',
     exec: function(args, context) {
       return debugAndroid(context.environment.chromeWindow, context.environment.window);
-    }   
+    }
   }
 ];
 


### PR DESCRIPTION
The initial connection when starting the iOS proxy might not show any tabs.

If we keep trying, it will appear and then the GCLI command "ios" will work as expected.
