### PR TITLE
force returned value of `sources` request to an array, fixes debugger

### DIFF
--- a/lib/chromium/thread.js
+++ b/lib/chromium/thread.js
@@ -453,6 +453,7 @@ var ChromiumThreadActor = ActorClass({
     let source;
     if (!this._sources.has(url)) {
       source = new SourceActor(this, url);
+      this.manage(source);
       this._sources.set(url, source);
     } else {
       source = this._sources.get(url);
@@ -654,7 +655,7 @@ var ChromiumThreadActor = ActorClass({
       this.sourceRef(script.url, script);
     }
 
-    return this._sources.values();
+    return [...this._sources.values()];
   }, {
     request: {},
     response: {


### PR DESCRIPTION
I don't know how this ever worked, but this fixes it for me.