### PR TITLE
Remove types by name, instead of tracking our own set. Fixes #7, #190.

### DIFF
--- a/lib/chromium/highlighter.js
+++ b/lib/chromium/highlighter.js
@@ -1,13 +1,13 @@
 const task = require("../util/task");
 
 const protocol = require("../devtools-require")("devtools/server/protocol");
-const {asyncMethod, ActorClass, types} = require("../util/protocol-extra");
+const {asyncMethod, types} = require("../util/protocol-extra");
 const {Actor, Pool, method, Arg, Option, RetVal, emit} = protocol;
 
 const timers = require("sdk/timers");
 const HIGHLIGHTER_PICKED_TIMER = 1000;
 
-var ChromiumHighlighterActor = ActorClass({
+var ChromiumHighlighterActor = protocol.ActorClass({
   typeName: "chromium_highlighter",
 
   initialize: function(inspector, autohide) {
@@ -73,4 +73,3 @@ var ChromiumHighlighterActor = ActorClass({
   }),
 });
 exports.ChromiumHighlighterActor = ChromiumHighlighterActor;
-

--- a/lib/chromium/inspector.js
+++ b/lib/chromium/inspector.js
@@ -1,7 +1,7 @@
 const task = require("../util/task");
 
 const protocol = require("../devtools-require")("devtools/server/protocol");
-const {asyncMethod, ActorClass, types} = require("../util/protocol-extra");
+const {asyncMethod, types} = require("../util/protocol-extra");
 const {Actor, Pool, method, Arg, Option, RetVal, emit} = protocol;
 const {ChromiumWalkerActor} = require("./walker");
 const {ChromiumPageStyleActor} = require("./styles");
@@ -9,7 +9,7 @@ const {ChromiumHighlighterActor} = require("./highlighter");
 const {LongStringActor} = require("../devtools-require")("devtools/server/actors/string");
 const {getResourceStore} = require("./resource-store");
 
-var ChromiumInspectorActor = ActorClass({
+var ChromiumInspectorActor = protocol.ActorClass({
   typeName: "chromium_inspector",
 
   initialize: function(tab) {

--- a/lib/chromium/reflow.js
+++ b/lib/chromium/reflow.js
@@ -1,7 +1,7 @@
 const task = require("../util/task");
 
 const protocol = require("../devtools-require")("devtools/server/protocol");
-const {asyncMethod, ActorClass, types} = require("../util/protocol-extra");
+const {asyncMethod, types} = require("../util/protocol-extra");
 const {Actor, Pool, method, Arg, Option, RetVal, emit} = protocol;
 const {setTimeout, clearTimeout} = require("sdk/timers");
 
@@ -25,7 +25,7 @@ const LAYOUT_INVALIDATION_EVENTS = [
   "Page.frameResized"
 ];
 
-var ChromiumReflowActor = ActorClass({
+var ChromiumReflowActor = protocol.ActorClass({
   typeName: "chromium_reflow",
 
   events: {

--- a/lib/chromium/root.js
+++ b/lib/chromium/root.js
@@ -9,7 +9,7 @@ const task = require("../util/task");
 
 const protocol = require("../devtools-require")("devtools/server/protocol");
 const {Actor, method, Arg, Option, RetVal, emit} = protocol;
-const {asyncMethod, ActorClass, types} = require("../util/protocol-extra");
+const {asyncMethod, types} = require("../util/protocol-extra");
 
 const {ChromiumConsoleActor} = require("./webconsole");
 const {ChromiumInspectorActor} = require("./inspector");
@@ -43,7 +43,7 @@ function requestTabs(url) {
 
 exports.requestTabs = requestTabs;
 
-var ChromiumRootActor = ActorClass({
+var ChromiumRootActor = protocol.ActorClass({
   typeName: "chromium_root",
 
   initialize: function(conn, url) {
@@ -142,7 +142,7 @@ var ChromiumRootActor = ActorClass({
 
 exports.ChromiumRootActor = ChromiumRootActor;
 
-var ChromiumTabActor = ActorClass({
+var ChromiumTabActor = protocol.ActorClass({
   typeName: "chromium_tab",
 
   events: {

--- a/lib/chromium/server.js
+++ b/lib/chromium/server.js
@@ -11,6 +11,10 @@ const {Pool} = require("../devtools-require")("devtools/server/protocol");
 const {DebuggerTransport, LocalDebuggerTransport} = require("../devtools-require")("devtools/toolkit/transport/transport");
 const DevToolsUtils = require("../devtools-require")("devtools/toolkit/DevToolsUtils");
 const {ChromiumRootActor, requestTabs} = require("./root");
+const {when: unload} = require("sdk/system/unload");
+
+let connID = 1;
+let connections = new Set();
 
 var Connection = Class({
   extends: Pool,
@@ -61,8 +65,14 @@ var Connection = Class({
     }
   }),
 
+  close() {
+    this.transport.close();
+    this.transport = null;
+  },
+
   onClosed: function() {
     this.root.destroy();
+    connections.delete(this);
   },
 
   allocID: function(prefix) {
@@ -114,12 +124,16 @@ var Connection = Class({
     this.pools.add(pool);
   },
   removeActorPool: function(pool) {
-    this.pools.remove(pool);
+    this.pools.delete(pool);
   }
 });
 
-let connID = 1;
-let connections = new Set();
+unload(() => {
+  for (let conn of connections) {
+    conn.close();
+  }
+});
+
 exports.connect = function (url="http://localhost:9222") {
   let serverTransport = new LocalDebuggerTransport();
   let clientTransport = new LocalDebuggerTransport(serverTransport);

--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -2,7 +2,7 @@ const {Cc, Ci, Cu} = require("chrome");
 
 const protocol = require("../devtools-require")("devtools/server/protocol");
 const {Actor, method, Arg, Option, RetVal, emit} = protocol;
-const {asyncMethod, todoMethod, todoMethodSilent, types, ActorClass} = require("../util/protocol-extra");
+const {asyncMethod, todoMethod, todoMethodSilent, types} = require("../util/protocol-extra");
 const {LongStringActor} = require("../devtools-require")("devtools/server/actors/string");
 const {CssLogic} = require("../devtools-require")("devtools/styleinspector/css-logic");
 const task = require("../util/task");
@@ -39,7 +39,7 @@ function DOMUtils() {
   return Cc["@mozilla.org/inspector/dom-utils;1"].getService(Ci.inIDOMUtils);
 }
 
-var ChromiumPageStyleActor = ActorClass({
+var ChromiumPageStyleActor = protocol.ActorClass({
   typeName: "chromium_pagestyle",
 
   initialize: function(inspector) {
@@ -570,7 +570,7 @@ var ChromiumPageStyleActor = ActorClass({
 });
 exports.ChromiumPageStyleActor = ChromiumPageStyleActor;
 
-var ChromiumStyleSheetActor = ActorClass({
+var ChromiumStyleSheetActor = protocol.ActorClass({
   typeName: "chromium_stylesheet",
 
   initialize: function(parent, header) {
@@ -658,7 +658,7 @@ var ChromiumStyleSheetActor = ActorClass({
   })
 });
 
-var ChromiumStyleRuleActor = ActorClass({
+var ChromiumStyleRuleActor = protocol.ActorClass({
   typeName: "chromium_domstylerule",
 
   initialize: function(pageStyle, handle) {
@@ -788,7 +788,7 @@ var ChromiumStyleRuleActor = ActorClass({
 
 // XXX: Don't do the media change actor yet.
 
-var ChromiumStyleSheetsActor = ActorClass({
+var ChromiumStyleSheetsActor = protocol.ActorClass({
   typeName: "chromium_stylesheets",
 
   initialize: function(tab) {

--- a/lib/chromium/thread.js
+++ b/lib/chromium/thread.js
@@ -4,7 +4,7 @@ const {URL} = require("sdk/url");
 
 const {Class} = require("sdk/core/heritage");
 const protocol = require("../devtools-require")("devtools/server/protocol");
-const {asyncMethod, ActorClass, types} = require("../util/protocol-extra");
+const {asyncMethod, types} = require("../util/protocol-extra");
 const {Actor, Pool, method, Arg, Option, RetVal, emit} = protocol;
 const {LongStringActor} = require("../devtools-require")("devtools/server/actors/string");
 const {fetch} = require("../devtools-require")("devtools/toolkit/DevToolsUtils");
@@ -17,7 +17,7 @@ const {normalize} = require("./resource-store");
 types.addLifetime("pause", "pauseActor");
 types.addLifetime("thread", "threadActor");
 
-var PauseActor = ActorClass({
+var PauseActor = protocol.ActorClass({
   typeName: "chromium_pauseactor",
   initialize: function(conn, rpc) {
     this.rpc = rpc;
@@ -26,7 +26,7 @@ var PauseActor = ActorClass({
   form: function(detail) { return this.actorID; }
 });
 
-var BreakpointActor = ActorClass({
+var BreakpointActor = protocol.ActorClass({
   typeName: "chromium_breakpoint",
   initialize: function(thread, breakpointId) {
     this.thread = thread;
@@ -53,7 +53,7 @@ var BreakpointActor = ActorClass({
   })
 })
 
-var EnvironmentActor = ActorClass({
+var EnvironmentActor = protocol.ActorClass({
   typeName: "chromium_environment",
 
   initialize: function(thread, scope) {
@@ -80,7 +80,7 @@ var EnvironmentActor = ActorClass({
   }
 })
 
-var FrameActor = ActorClass({
+var FrameActor = protocol.ActorClass({
   typeName: "chromium_frame",
   initialize: function(thread, frame) {
     this.thread = thread;
@@ -223,7 +223,7 @@ var Stack = Class({
   }
 })
 
-var SourceActor = ActorClass({
+var SourceActor = protocol.ActorClass({
   typeName: "chromium_source",
   initialize: function(thread, url) {
     this.thread = thread;
@@ -338,7 +338,7 @@ var SourceActor = ActorClass({
   }
 });
 
-var ChromiumThreadActor = ActorClass({
+var ChromiumThreadActor = protocol.ActorClass({
   typeName: "chromium_thread",
 
   events: {

--- a/lib/chromium/value.js
+++ b/lib/chromium/value.js
@@ -4,7 +4,7 @@
 
 const protocol = require("../devtools-require")("devtools/server/protocol");
 const {Actor, method, Arg, Option, RetVal} = protocol;
-const {asyncMethod, types, ActorClass} = require("../util/protocol-extra");
+const {asyncMethod, types} = require("../util/protocol-extra");
 const {stringify} = require("./stringify");
 
 exports.convertProperty = function(chrProp) {
@@ -77,7 +77,7 @@ types.addDictType("chromium_property", {
 
 types.addUniformDictType("chromium_propertylist", "chromium_property");
 
-var ObjectGrip = ActorClass({
+var ObjectGrip = protocol.ActorClass({
   typeName: "chromium_objectgrip",
 
   initialize: function(conn, rpc, handle) {

--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -3,7 +3,7 @@ const { Ci, Cu, Cc } = require("chrome");
 const task = require("../util/task");
 
 const protocol = require("../devtools-require")("devtools/server/protocol");
-const {asyncMethod, todoMethod, todoMethodSilent, ActorClass, types} = require("../util/protocol-extra");
+const {asyncMethod, todoMethod, todoMethodSilent, types} = require("../util/protocol-extra");
 const {Actor, Pool, method, Arg, Option, RetVal, emit} = protocol;
 const {ChromiumPageStyleActor} = require("./styles");
 const {LongStringActor} = require("../devtools-require")("devtools/server/actors/string");
@@ -33,7 +33,7 @@ types.addDictType("chromium_imageData", {
   size: "json"
 });
 
-var NodeActor = ActorClass({
+var NodeActor = protocol.ActorClass({
   typeName: "chromium_domnode",
 
   get conn() { return this.walker.conn; },
@@ -291,7 +291,7 @@ var NodeActor = ActorClass({
 });
 
 
-var NodeListActor = ActorClass({
+var NodeListActor = protocol.ActorClass({
   typeName: "chromium_domnodelist",
 
   get conn() { return this.walker.conn; },
@@ -373,7 +373,7 @@ const pseudoClassMethod = {
   response: {}
 };
 
-var ChromiumWalkerActor = ActorClass({
+var ChromiumWalkerActor = protocol.ActorClass({
   typeName: "chromium_domwalker",
 
   events: {

--- a/lib/chromium/webconsole.js
+++ b/lib/chromium/webconsole.js
@@ -2,7 +2,7 @@ const {Class} = require("sdk/core/heritage");
 const task = require("../util/task");
 
 const protocol = require("../devtools-require")("devtools/server/protocol");
-const {asyncMethod, ActorClass, types} = require("../util/protocol-extra");
+const {asyncMethod, types} = require("../util/protocol-extra");
 const {Actor, Pool, method, Arg, Option, RetVal, emit} = protocol;
 const values = require("./value");
 const preview = require("./preview");
@@ -19,7 +19,7 @@ types.addDictType("chromium_pageerror", {
   "errorMessage": "string",
 });
 
-var ChromiumConsoleActor = ActorClass({
+var ChromiumConsoleActor = protocol.ActorClass({
   typeName: "chromium_console",
 
   toString: function() { return "[ConsoleActor:" + this.actorID + "]" },
@@ -65,9 +65,9 @@ var ChromiumConsoleActor = ActorClass({
   }),
 
   toConsoleAPIMessage: function(msg) {
-//     type ( optional enumerated string [ "assert" , "clear" , "dir" , 
+//     type ( optional enumerated string [ "assert" , "clear" , "dir" ,
 // "dirxml" , "endGroup" , "log" , "profile" , "profileEnd" , "startGroup" ,
-// "startGroupCollapsed" , "table" , "timing" , "trace" ] ) 
+// "startGroupCollapsed" , "table" , "timing" , "trace" ] )
     let payload = {
       "level": msg.level == "warning" ? "warn" : msg.level,
       "arguments": msg.parameters ||

--- a/lib/util/protocol-extra.js
+++ b/lib/util/protocol-extra.js
@@ -34,7 +34,7 @@ unload.when(() => {
     return;
   }
   for (let name of types.registeredTypes.keys()) {
-    if (name.includes("chromium")) {
+    if (name.contains("chromium")) {
       types.removeType(name);
     }
   }

--- a/lib/util/protocol-extra.js
+++ b/lib/util/protocol-extra.js
@@ -1,4 +1,4 @@
-let { method, types, ActorClass } = require("../devtools-require")("devtools/server/protocol");
+let { method, types } = require("../devtools-require")("devtools/server/protocol");
 let task = require("./task");
 let unload = require("sdk/system/unload");
 
@@ -26,34 +26,17 @@ exports.todoMethodSilent = function(spec) {
  * on addon unload
  */
 
-var myTypes = new Set();
-
-exports.ActorClass = function(proto) {
-  let type = ActorClass(proto);
-  myTypes.add(proto.typeName);
-  return type;
-}
-
-exports.types = {};
-
-[
-  "addType",
-  "addArrayTpe",
-  "addDictType",
-  "addNullableType",
-  "addActorType",
-  "addActorDetail",
-].forEach(registrator => {
-  exports.types[registrator] = function(...args) {
-    let type = types[registrator](...args);
-    myTypes.add(type.name);
-    return type;
-  }
-});
+exports.types = Object.assign({}, types);
 
 unload.when(() => {
-  for (let name of myTypes) {
-    types.removeType(name);
+  // Only Fx 41+ exports registeredTypes
+  if (!types.registeredTypes) {
+    return;
+  }
+  for (let name of types.registeredTypes.keys()) {
+    if (name.includes("chromium")) {
+      types.removeType(name);
+    }
   }
 });
 


### PR DESCRIPTION
In #98, some work was done to try to remove types Valence registers when the add-on is unloaded.

However, it never really caught all of them. The reason is that protocol.js registers some types lazily, so they did not pass through the Valence wrapper methods in `protocol-extra.js`, which means we didn't know we needed to remove them at unload time.

Rather than getting even fancier here, it's simpler for protocol.js to export the type set, and we can dig through it and find all the ones we know came from us.

This depends on [bug 1176137][1] for unload to actually work. For Firefox without that bug's patch, the add-on still works, but unloading continues to fail, as it did before, so no behavior change.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1176137