### PR TITLE
Update paths after DevTools file migration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,407 @@
+{
+  "env": {
+    "es6": true
+  },
+  "globals": {
+    "Cc": true,
+    "Ci": true,
+    "Components": true,
+    "console": true,
+    "Cr": true,
+    "Cu": true,
+    "devtools": true,
+    "dump": true,
+    "EventEmitter": true,
+    "exports": true,
+    "loader": true,
+    "module": true,
+    "require": true,
+    "Services": true,
+    "Task": true,
+    "XPCOMUtils": true,
+    "XPCNativeWrapper": true,
+  },
+  "rules": {
+    // These are the rules that have been configured so far to match the
+    // devtools coding style.
+
+    // Disallow using variables outside the blocks they are defined (especially
+    // since only let and const are used, see "no-var").
+    "block-scoped-var": 2,
+    // Enforce one true brace style (opening brace on the same line) and avoid
+    // start and end braces on the same line.
+    "brace-style": [2, "1tbs", {"allowSingleLine": false}],
+    // Require camel case names
+    "camelcase": 2,
+    // Allow trailing commas for easy list extension.  Having them does not
+    // impair readability, but also not required either.
+    "comma-dangle": 0,
+    // Enforce spacing before and after comma
+    "comma-spacing": [2, {"before": false, "after": true}],
+    // Enforce one true comma style.
+    "comma-style": [2, "last"],
+    // Warn about cyclomatic complexity in functions.
+    "complexity": 1,
+    // Require return statements to either always or never specify values.
+    "consistent-return": 2,
+    // Don't warn for inconsistent naming when capturing this (not so important
+    // with auto-binding fat arrow functions).
+    "consistent-this": 0,
+    // Enforce curly brace conventions for all control statements.
+    "curly": 2,
+    // Don't require a default case in switch statements. Avoid being forced to
+    // add a bogus default when you know all possible cases are handled.
+    "default-case": 0,
+    // Enforce dots on the next line with property name.
+    "dot-location": [1, "property"],
+    // Encourage the use of dot notation whenever possible.
+    "dot-notation": 2,
+    // Enforce newline at the end of file, with no multiple empty lines.
+    "eol-last": 2,
+    // Allow using == instead of ===, in the interest of landing something since
+    // the devtools codebase is split on convention here.
+    "eqeqeq": 0,
+    // Don't require function expressions to have a name.
+    // This makes the code more verbose and hard to read. Our engine already
+    // does a fantastic job assigning a name to the function, which includes
+    // the enclosing function name, and worst case you have a line number that
+    // you can just look up.
+    "func-names": 0,
+    // Allow use of function declarations and expressions.
+    "func-style": 0,
+    // Deprecated, will be removed in 1.0.
+    "generator-star": 0,
+    // Enforce the spacing around the * in generator functions.
+    "generator-star-spacing": [1, "after"],
+    // Deprecated, will be removed in 1.0.
+    "global-strict": 0,
+    // Only useful in a node environment.
+    "handle-callback-err": 0,
+    // Tab width.
+    "indent": [2, 2, {"SwitchCase": 1}],
+    // Enforces spacing between keys and values in object literal properties.
+    "key-spacing": [1, {"beforeColon": false, "afterColon": true}],
+    // Allow mixed 'LF' and 'CRLF' as linebreaks.
+    "linebreak-style": 0,
+    // Don't enforce the maximum depth that blocks can be nested. The complexity
+    // rule is a better rule to check this.
+    "max-depth": 0,
+    // Maximum length of a line.
+    "max-len": [1, 80],
+    // Maximum depth callbacks can be nested.
+    "max-nested-callbacks": [2, 3],
+    // Don't limit the number of parameters that can be used in a function.
+    "max-params": 0,
+    // Don't limit the maximum number of statement allowed in a function. We
+    // already have the complexity rule that's a better measurement.
+    "max-statements": 0,
+    // Require a capital letter for constructors, only check if all new
+    // operators are followed by a capital letter. Don't warn when capitalized
+    // functions are used without the new operator.
+    "new-cap": [2, {"capIsNew": false}],
+    // Disallow the omission of parentheses when invoking a constructor with no
+    // arguments.
+    "new-parens": 2,
+    // Disallow use of the Array constructor.
+    "no-array-constructor": 2,
+    // Allow use of bitwise operators.
+    "no-bitwise": 0,
+    // Disallow use of arguments.caller or arguments.callee.
+    "no-caller": 2,
+    // Disallow the catch clause parameter name being the same as a variable in
+    // the outer scope, to avoid confusion.
+    "no-catch-shadow": 1,
+    // Deprecated, will be removed in 1.0.
+    "no-comma-dangle": 0,
+    // Disallow assignment in conditional expressions.
+    "no-cond-assign": 2,
+    // Allow using the console API.
+    "no-console": 0,
+    // Allow using constant expressions in conditions like while (true)
+    "no-constant-condition": 0,
+    // Allow use of the continue statement.
+    "no-continue": 0,
+    // Disallow control characters in regular expressions.
+    "no-control-regex": 2,
+    // Disallow use of debugger.
+    "no-debugger": 2,
+    // Disallow deletion of variables (deleting properties is fine).
+    "no-delete-var": 2,
+    // Allow division operators explicitly at beginning of regular expression.
+    "no-div-regex": 0,
+    // Disallow duplicate arguments in functions.
+    "no-dupe-args": 2,
+    // Disallow duplicate keys when creating object literals.
+    "no-dupe-keys": 2,
+    // Disallow a duplicate case label.
+    "no-duplicate-case": 2,
+    // Disallow else after a return in an if. The else around the second return
+    // here is useless:
+    // if (something) { return false; } else { return true; }
+    "no-else-return": 2,
+    // Disallow empty statements. This will report an error for:
+    // try { something(); } catch (e) {}
+    // but will not report it for:
+    // try { something(); } catch (e) { /* Silencing the error because ...*/ }
+    // which is a valid use case.
+    "no-empty": 2,
+    // Disallow the use of empty character classes in regular expressions.
+    "no-empty-character-class": 2,
+    // Disallow use of labels for anything other then loops and switches.
+    "no-empty-label": 2,
+    // Disallow use of eval(). We have other APIs to evaluate code in content.
+    "no-eval": 2,
+    // Disallow assigning to the exception in a catch block.
+    "no-ex-assign": 2,
+    // Disallow adding to native types
+    "no-extend-native": 2,
+    // Disallow unnecessary function binding.
+    "no-extra-bind": 2,
+    // Disallow double-negation boolean casts in a boolean context.
+    "no-extra-boolean-cast": 2,
+    // Allow unnecessary parentheses, as they may make the code more readable.
+    "no-extra-parens": 0,
+    // Disallow unnecessary semicolons.
+    "no-extra-semi": 2,
+    // Deprecated, will be removed in 1.0.
+    "no-extra-strict": 0,
+    // Disallow fallthrough of case statements, except if there is a comment.
+    "no-fallthrough": 2,
+    // Allow the use of leading or trailing decimal points in numeric literals.
+    "no-floating-decimal": 0,
+    // Disallow comments inline after code.
+    "no-inline-comments": 1,
+    // Disallow if as the only statement in an else block.
+    "no-lonely-if": 2,
+    // Allow mixing regular variable and require declarations (not a node env).
+    "no-mixed-requires": 0,
+    // Disallow mixed spaces and tabs for indentation.
+    "no-mixed-spaces-and-tabs": 2,
+    // Disallow use of multiple spaces (sometimes used to align const values,
+    // array or object items, etc.). It's hard to maintain and doesn't add that
+    // much benefit.
+    "no-multi-spaces": 1,
+    // Disallow use of multiline strings (use template strings instead).
+    "no-multi-str": 1,
+    // Disallow multiple empty lines.
+    "no-multiple-empty-lines": [1, {"max": 1}],
+    // Disallow reassignments of native objects.
+    "no-native-reassign": 2,
+    // Disallow nested ternary expressions, they make the code hard to read.
+    "no-nested-ternary": 2,
+    // Allow use of new operator with the require function.
+    "no-new-require": 0,
+    // Disallow use of octal literals.
+    "no-octal": 1,
+    // Allow reassignment of function parameters.
+    "no-param-reassign": 0,
+    // Allow string concatenation with __dirname and __filename (not a node env).
+    "no-path-concat": 0,
+    // Allow use of unary operators, ++ and --.
+    "no-plusplus": 0,
+    // Allow using process.env (not a node environment).
+    "no-process-env": 0,
+    // Allow using process.exit (not a node environment).
+    "no-process-exit": 0,
+    // Disallow usage of __proto__ property.
+    "no-proto": 2,
+    // Disallow declaring the same variable more than once (we use let anyway).
+    "no-redeclare": 2,
+    // Disallow multiple spaces in a regular expression literal.
+    "no-regex-spaces": 2,
+    // Allow reserved words being used as object literal keys.
+    "no-reserved-keys": 0,
+    // Don't restrict usage of specified node modules (not a node environment).
+    "no-restricted-modules": 0,
+    // Disallow use of assignment in return statement. It is preferable for a
+    // single line of code to have only one easily predictable effect.
+    "no-return-assign": 2,
+    // Allow use of javascript: urls.
+    "no-script-url": 0,
+    // Disallow comparisons where both sides are exactly the same.
+    "no-self-compare": 2,
+    // Disallow use of comma operator.
+    "no-sequences": 2,
+    // Warn about declaration of variables already declared in the outer scope.
+    // This isn't an error because it sometimes is useful to use the same name
+    // in a small helper function rather than having to come up with another
+    // random name.
+    // Still, making this a warning can help people avoid being confused.
+    "no-shadow": 1,
+    // Disallow shadowing of names such as arguments.
+    "no-shadow-restricted-names": 2,
+    // Deprecated, will be removed in 1.0.
+    "no-space-before-semi": 0,
+    // Disallow space between function identifier and application.
+    "no-spaced-func": 1,
+    // Disallow sparse arrays, eg. let arr = [,,2].
+    // Array destructuring is fine though:
+    // for (let [, breakpointPromise] of aPromises)
+    "no-sparse-arrays": 2,
+    // Allow use of synchronous methods (not a node environment).
+    "no-sync": 0,
+    // Allow the use of ternary operators.
+    "no-ternary": 0,
+    // Disallow throwing literals (eg. throw "error" instead of
+    // throw new Error("error")).
+    "no-throw-literal": 2,
+    // Disallow trailing whitespace at the end of lines.
+    "no-trailing-spaces": 2,
+    // Disallow use of undeclared variables unless mentioned in a /*global */
+    // block.
+    // This should really be a 2, but until we define all globals in comments
+    // and .eslintrc, keeping this as a 1.
+    "no-undef": 2,
+    // Allow dangling underscores in identifiers (for privates).
+    "no-underscore-dangle": 0,
+    // Allow use of undefined variable.
+    "no-undefined": 0,
+    // Disallow the use of Boolean literals in conditional expressions.
+    "no-unneeded-ternary": 2,
+    // Disallow unreachable statements after a return, throw, continue, or break
+    // statement.
+    "no-unreachable": 2,
+    // Disallow declaration of variables that are not used in the code
+    "no-unused-vars": 2,
+    // Allow using variables before they are defined.
+    "no-use-before-define": 0,
+    // Require let or const instead of var.
+    "no-var": 2,
+    // Allow using TODO/FIXME comments.
+    "no-warning-comments": 0,
+    // Disallow use of the with statement.
+    "no-with": 2,
+    // Don't require method and property shorthand syntax for object literals.
+    // We use this in the code a lot, but not consistently, and this seems more
+    // like something to check at code review time.
+    "object-shorthand": 0,
+    // Allow more than one variable declaration per function.
+    "one-var": 0,
+    // Disallow padding within blocks.
+    "padded-blocks": [1, "never"],
+    // Don't require quotes around object literal property names.
+    "quote-props": 0,
+    // Double quotes should be used.
+    "quotes": [1, "double", "avoid-escape"],
+    // Require use of the second argument for parseInt().
+    "radix": 2,
+    // Always require use of semicolons wherever they are valid.
+    "semi": [1, "always"],
+    // Enforce spacing after semicolons.
+    "semi-spacing": [1, {"before": false, "after": true}],
+    // Don't require to sort variables within the same declaration block.
+    // Anyway, one-var is disabled.
+    "sort-vars": 0,
+    // Deprecated, will be removed in 1.0.
+    "space-after-function-name": 0,
+    // Require a space after keywords.
+    "space-after-keywords": [1, "always"],
+    // Deprecated, will be removed in 1.0.
+    "space-after-function-name": 0,
+    // Require a space before the start brace of a block.
+    "space-before-blocks": [1, "always"],
+    // Deprecated, will be removed in 1.0.
+    "space-before-function-parentheses": 0,
+    // Disallow space before function opening parenthesis.
+    "space-before-function-paren": [1, "never"],
+    // Disable the rule that checks if spaces inside {} and [] are there or not.
+    // Our code is split on conventions, and it'd be nice to have 2 rules
+    // instead, one for [] and one for {}. So, disabling until we write them.
+    "space-in-brackets": 0,
+    // Disallow spaces inside parentheses.
+    "space-in-parens": [1, "never"],
+    // Require spaces around operators, except for a|0.
+    "space-infix-ops": [1, {"int32Hint": true}],
+    // Require a space after return, throw, and case.
+    "space-return-throw-case": 1,
+    // Require spaces before/after unary operators (words on by default,
+    // nonwords off by default).
+    "space-unary-ops": [1, { "words": true, "nonwords": false }],
+    // Deprecated, will be removed in 1.0.
+    "space-unary-word-ops": 0,
+    // Require a space immediately following the // in a line comment.
+    "spaced-comment": [1, "always"],
+    // Require "use strict" to be defined globally in the script.
+    "strict": [2, "global"],
+    // Disallow comparisons with the value NaN.
+    "use-isnan": 2,
+    // Warn about invalid JSDoc comments.
+    // Disabled for now because of https://github.com/eslint/eslint/issues/2270
+    // The rule fails on some jsdoc comments like in:
+    // devtools/client/webconsole/console-output.js
+    "valid-jsdoc": 0,
+    // Ensure that the results of typeof are compared against a valid string.
+    "valid-typeof": 2,
+    // Allow vars to be declared anywhere in the scope.
+    "vars-on-top": 0,
+    // Don't require immediate function invocation to be wrapped in parentheses.
+    "wrap-iife": 0,
+    // Don't require regex literals to be wrapped in parentheses (which
+    // supposedly prevent them from being mistaken for division operators).
+    "wrap-regex": 0,
+    // Disallow Yoda conditions (where literal value comes first).
+    "yoda": 2,
+
+    // And these are the rules that haven't been discussed so far, and that are
+    // disabled for now until we introduce them, one at a time.
+
+    // Require for-in loops to have an if statement.
+    "guard-for-in": 0,
+    // allow/disallow an empty newline after var statement
+    "newline-after-var": 0,
+    // disallow the use of alert, confirm, and prompt
+    "no-alert": 0,
+    // disallow comparisons to null without a type-checking operator
+    "no-eq-null": 0,
+    // disallow overwriting functions written as function declarations
+    "no-func-assign": 0,
+    // disallow use of eval()-like methods
+    "no-implied-eval": 0,
+    // disallow function or variable declarations in nested blocks
+    "no-inner-declarations": 0,
+    // disallow invalid regular expression strings in the RegExp constructor
+    "no-invalid-regexp": 0,
+    // disallow irregular whitespace outside of strings and comments
+    "no-irregular-whitespace": 0,
+    // disallow usage of __iterator__ property
+    "no-iterator": 0,
+    // disallow labels that share a name with a variable
+    "no-label-var": 0,
+    // disallow use of labeled statements
+    "no-labels": 0,
+    // disallow unnecessary nested blocks
+    "no-lone-blocks": 0,
+    // disallow creation of functions within loops
+    "no-loop-func": 0,
+    // disallow negation of the left operand of an in expression
+    "no-negated-in-lhs": 0,
+    // disallow use of new operator when not part of the assignment or
+    // comparison
+    "no-new": 0,
+    // disallow use of new operator for Function object
+    "no-new-func": 0,
+    // disallow use of the Object constructor
+    "no-new-object": 0,
+    // disallows creating new instances of String,Number, and Boolean
+    "no-new-wrappers": 0,
+    // disallow the use of object properties of the global object (Math and
+    // JSON) as functions
+    "no-obj-calls": 0,
+    // disallow use of octal escape sequences in string literals, such as
+    // var foo = "Copyright \251";
+    "no-octal-escape": 0,
+    // disallow use of undefined when initializing variables
+    "no-undef-init": 0,
+    // disallow usage of expressions in statement position
+    "no-unused-expressions": 0,
+    // disallow use of void operator
+    "no-void": 0,
+    // disallow wrapping of non-IIFE statements in parens
+    "no-wrap-func": 0,
+    // require assignment operator shorthand where possible or prohibit it
+    // entirely
+    "operator-assignment": 0,
+    // enforce operators to be placed before or after line breaks
+    "operator-linebreak": 0,
+  }
+}

--- a/lib/chromium/console-utils.js
+++ b/lib/chromium/console-utils.js
@@ -1,4 +1,4 @@
-const DevToolsUtils = require("../devtools-require")("devtools/toolkit/DevToolsUtils");
+const DevToolsUtils = require("../devtools-require")("devtools/shared/DevToolsUtils");
 const values = require("./value");
 
 // Provide an easy way to bail out of even attempting an autocompletion

--- a/lib/chromium/server.js
+++ b/lib/chromium/server.js
@@ -8,8 +8,8 @@ const {Class} = require("sdk/core/heritage");
 const {prefs} = require("sdk/simple-prefs");
 const task = require("../util/task");
 const {Pool} = require("../devtools-require")("devtools/server/protocol");
-const {DebuggerTransport, LocalDebuggerTransport} = require("../devtools-require")("devtools/toolkit/transport/transport");
-const DevToolsUtils = require("../devtools-require")("devtools/toolkit/DevToolsUtils");
+const {DebuggerTransport, LocalDebuggerTransport} = require("../devtools-require")("devtools/shared/transport/transport");
+const DevToolsUtils = require("../devtools-require")("devtools/shared/DevToolsUtils");
 const {ChromiumRootActor, requestTabs} = require("./root");
 const {when: unload} = require("sdk/system/unload");
 

--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -4,7 +4,7 @@ const protocol = require("../devtools-require")("devtools/server/protocol");
 const {Actor, method, Arg, Option, RetVal, emit} = protocol;
 const {asyncMethod, todoMethod, todoMethodSilent, types} = require("../util/protocol-extra");
 const {LongStringActor} = require("../devtools-require")("devtools/server/actors/string");
-const {CssLogic} = require("../devtools-require")("devtools/styleinspector/css-logic");
+const {CssLogic} = require("../devtools-require")("devtools/shared/styleinspector/css-logic");
 const task = require("../util/task");
 
 protocol.types.addActorType("chromium_domnode");

--- a/lib/chromium/thread.js
+++ b/lib/chromium/thread.js
@@ -7,7 +7,7 @@ const protocol = require("../devtools-require")("devtools/server/protocol");
 const {asyncMethod, types} = require("../util/protocol-extra");
 const {Actor, Pool, method, Arg, Option, RetVal, emit} = protocol;
 const {LongStringActor} = require("../devtools-require")("devtools/server/actors/string");
-const {fetch} = require("../devtools-require")("devtools/toolkit/DevToolsUtils");
+const {fetch} = require("../devtools-require")("devtools/shared/DevToolsUtils");
 
 const values = require("./value");
 const preview = require("./preview");

--- a/lib/devtools-import.js
+++ b/lib/devtools-import.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const { Cu } = require("chrome");
+
+// In Firefox 44 and later, many DevTools modules were relocated.
+// See https://bugzil.la/912121
+const PATH_RENAMES = [
+  {
+    regex: /^resource:\/\/\/modules\/devtools\/client\/framework\//,
+    replacement: "resource:///modules/devtools/"
+  },
+  {
+    regex: /^resource:\/\/gre\/modules\/devtools\/shared\/apps\//,
+    replacement: "resource://gre/modules/devtools/"
+  },
+  {
+    regex: /^resource:\/\/gre\/modules\/devtools\/shared\//,
+    replacement: "resource://gre/modules/devtools/"
+  },
+];
+
+function scopedImport(path) {
+  let scope = {};
+  Cu.import(path, scope);
+  return scope;
+}
+
+function devtoolsImport(path) {
+  try {
+    return scopedImport(path);
+  } catch (e) {
+    // Attempt known renames for 43 and earlier
+    for (let { regex, replacement } of PATH_RENAMES) {
+      path = path.replace(regex, replacement);
+    }
+    return scopedImport(path);
+  }
+}
+
+module.exports = devtoolsImport;

--- a/lib/devtools-require.js
+++ b/lib/devtools-require.js
@@ -1,3 +1,39 @@
-const { Cu } = require("chrome");
-const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
-module.exports = devtools.require;
+"use strict";
+
+const { devtools } =
+  require("./devtools-import")("resource://gre/modules/devtools/shared/Loader.jsm");
+
+// In Firefox 44 and later, many DevTools modules were relocated.
+// See https://bugzil.la/912121
+const ID_RENAMES = [
+  {
+    regex: /^devtools\/client\/webide\/modules\//,
+    replacement: "devtools/webide/"
+  },
+  {
+    regex: /^devtools\/shared\/client\//,
+    replacement: "devtools/client/"
+  },
+  {
+    regex: /^devtools\/shared\/styleinspector\//,
+    replacement: "devtools/styleinspector/"
+  },
+  {
+    regex: /^devtools\/shared\//,
+    replacement: "devtools/toolkit/"
+  },
+];
+
+function devtoolsRequire(id) {
+  try {
+    return devtools.require(id);
+  } catch (e) {
+    // Attempt known renames for 43 and earlier
+    for (let { regex, replacement } of ID_RENAMES) {
+      id = id.replace(regex, replacement);
+    }
+    return devtools.require(id);
+  }
+}
+
+module.exports = devtoolsRequire;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,5 @@
-const {Cu} = require("chrome");
-const {gDevToolsBrowser} = Cu.import("resource:///modules/devtools/gDevTools.jsm");
+const { gDevToolsBrowser } =
+  require("./devtools-import")("resource:///modules/devtools/client/framework/gDevTools.jsm");
 
 // Add runtime entries to WebIDE
 function registerScanner() {

--- a/lib/util/ios-proxy.js
+++ b/lib/util/ios-proxy.js
@@ -1,5 +1,5 @@
 const { Cc, Ci } = require("chrome");
-const { makeInfallible } = require("../devtools-require")("devtools/toolkit/DevToolsUtils");
+const { makeInfallible } = require("../devtools-require")("devtools/shared/DevToolsUtils");
 
 const child_process = require("sdk/system/child_process");
 const Subprocess = require("sdk/system/child_process/subprocess");

--- a/lib/util/scanner.js
+++ b/lib/util/scanner.js
@@ -1,11 +1,11 @@
 const { Cu } = require("chrome");
-const { devtools } =
-  Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
-const EventEmitter = devtools.require("devtools/toolkit/event-emitter");
+const EventEmitter =
+  require("../devtools-require")("devtools/shared/event-emitter");
 const task = require("./task");
 const { Devices } =
-  Cu.import("resource://gre/modules/devtools/Devices.jsm", {});
-const Runtimes = devtools.require("devtools/webide/runtimes");
+  require("../devtools-import")("resource://gre/modules/devtools/shared/apps/Devices.jsm");
+const Runtimes =
+  require("../devtools-require")("devtools/client/webide/modules/runtimes");
 const server = require("../chromium/server");
 
 let Scanner = {
@@ -101,7 +101,7 @@ var iOSRuntime = {
   type: Runtimes.RuntimeTypes.OTHER,
   connect: task.async(function*(connection) {
     const { Connection } =
-      devtools.require("devtools/client/connection-manager");
+      require("../devtools-require")("devtools/shared/client/connection-manager");
     const iOSProxy = require("./ios-proxy");
     yield iOSProxy.start();
     console.log("Connecting to http://localhost:9230");
@@ -128,7 +128,7 @@ AdbRuntime.prototype = {
   type: Runtimes.RuntimeTypes.USB,
   connect: function(connection) {
     const { ConnectionManager } =
-      devtools.require("devtools/client/connection-manager");
+      require("../devtools-require")("devtools/shared/client/connection-manager");
     let port = ConnectionManager.getFreeTCPPort();
     let local = "tcp:" + port;
     let remote = this._socketType + ":" + this._socketPath;


### PR DESCRIPTION
This should get things working again for 44, while also maintaining compatibility in older releases.

I tested this in 43 and 44, but additional testing by others would be good to have.

r? @past