### PR TITLE
Restore inspector panels

### DIFF
--- a/lib/chromium/styles.js
+++ b/lib/chromium/styles.js
@@ -306,7 +306,7 @@ var ChromiumPageStyleActor = protocol.ActorClass({
       if (matchingSelectors && rule.handle.selectorList) {
         for (let i of matchingSelectors) {
           let selector = rule.handle.selectorList.selectors[i];
-          matchedSelectors.push(selector.value || selector);
+          matchedSelectors.push(selector.text || selector.value || selector);
         }
       }
 
@@ -711,7 +711,7 @@ var ChromiumStyleRuleActor = protocol.ActorClass({
         if (typeof(selector) === "string") {
           form.selectors.push(selector);
         } else {
-          form.selectors.push(selector.value);
+          form.selectors.push(selector.text || selector.value);
         }
       }
     }

--- a/lib/chromium/thread.js
+++ b/lib/chromium/thread.js
@@ -547,7 +547,10 @@ var ChromiumThreadActor = protocol.ActorClass({
     }
 
     yield this.rpc.request("Runtime.enable");
-    yield this.rpc.request("Debugger.enable");
+
+    // Start debugger without waiting for reply.
+    // We need to reach "paused" state before sources come in.
+    this.rpc.request("Debugger.enable");
 
     this.state = "attached";
     this.attaching = true;
@@ -576,7 +579,9 @@ var ChromiumThreadActor = protocol.ActorClass({
   }),
 
   pseudoPause: task.async(function*(options) {
-    yield this.rpc.request("Debugger.pause");
+    // Pause debugger without waiting for reply.
+    // We need to reach "paused" state before sources come in.
+    this.rpc.request("Debugger.pause");
     this.pauseOutstanding = true;
     this.startPause(options);
   }),


### PR DESCRIPTION
@tromey, could you review this?

To get the computed view and box model to work, I strangely enough had to repair the debugger. On some pages, the following would happen:

1. Client sends "attach" thread
2. Client is expecting a "paused" event reply
3. Valence sends "Debugger.enable" to device and waits for reply
4. Device emits each source on page
5. Valence sends "newSource" to the client (incorrectly, we want the "paused" event to go out first)
6. Device says "Debugger.enable" complete
7. Client thinks the "newSource" was the reply to "attach", so it sends "resumed" even we aren't paused yet

The state machine breaks down from here. This leaves the debugger in a strange state, always thinking it is paused.

The Valence style actors use the debugger to query the DOM, so the confused debugger seems to be what broke them.

That fixes #206 affecting all side panels in the inspector.

For the rule view, there is still the selector problem in bug 1246522. This is caused by a different protocol structure for the selectors in iOS 9.
